### PR TITLE
Feature/club like api

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/controller/ClubLikeController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/controller/ClubLikeController.java
@@ -1,0 +1,28 @@
+package com.mobble.mobbleserver.domain.like.clubLike.controller;
+
+import com.mobble.mobbleserver.domain.like.clubLike.dto.response.ClubLikeResponseDto;
+import com.mobble.mobbleserver.domain.like.clubLike.service.ClubLikeService;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("clubs/{club-id}/likes")
+public class ClubLikeController {
+
+    private final ClubLikeService clubLikeService;
+
+    @PostMapping
+    public ResponseEntity<ClubLikeResponseDto> likeToggle(
+            @PathVariable("club-id") @Positive Long clubId
+    ) {
+        Long memberId = 1L;
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(clubLikeService.toggleLike(clubId, memberId));
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/dto/response/ClubLikeResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/dto/response/ClubLikeResponseDto.java
@@ -1,0 +1,8 @@
+package com.mobble.mobbleserver.domain.like.clubLike.dto.response;
+
+public record ClubLikeResponseDto(Long clubId, boolean isLiked, int likeCount) {
+
+    public static ClubLikeResponseDto toDto(Long clubId, boolean isLiked, int likeCount) {
+        return new ClubLikeResponseDto(clubId, isLiked, likeCount);
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLike.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLike.java
@@ -16,9 +16,8 @@ public class ClubLike {
     @Column(name = "club_like_id")
     private Long id;
 
-//Todo cascade, orphanRemoval = true 설정 필요
 //    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "club_id", nullable = false)
+//    @JoinColumn(name = "club_id")
 //    private Club club;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/repository/ClubLikeRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/repository/ClubLikeRepository.java
@@ -3,13 +3,11 @@ package com.mobble.mobbleserver.domain.like.clubLike.repository;
 import com.mobble.mobbleserver.domain.like.clubLike.entity.ClubLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ClubLikeRepository extends JpaRepository<ClubLike, Long> {
 
-    Optional<ClubLike> findLikedByClubIdAndMemberId(Long clubId, Long memberId);
+//    Optional<ClubLike> findLikedByClubIdAndMemberId(Long clubId, Long memberId);
 
-    int countClubLikesByClubId(Long clubId);
+//    int countClubLikesByClubId(Long clubId);
 
-    boolean existsByClubIdAndMemberId(Long clubId, Long memberId);
+//    boolean existsByClubIdAndMemberId(Long clubId, Long memberId);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/repository/ClubLikeRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/repository/ClubLikeRepository.java
@@ -3,6 +3,13 @@ package com.mobble.mobbleserver.domain.like.clubLike.repository;
 import com.mobble.mobbleserver.domain.like.clubLike.entity.ClubLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClubLikeRepository extends JpaRepository<ClubLike, Long> {
 
+    Optional<ClubLike> findLikedByClubIdAndMemberId(Long clubId, Long memberId);
+
+    int countClubLikesByClubId(Long clubId);
+
+    boolean existsByClubIdAndMemberId(Long clubId, Long memberId);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
@@ -17,7 +17,7 @@ public class ClubLikeService {
 
 /*
     @Transactional
-    public ClubLikeResponseDto toggleLike(@Positive Long clubId, Long memberId) {
+    public ClubLikeResponseDto toggleLike(Long clubId, Long memberId) {
         Member member = findMemberOrThrow(memberId);
 //        Club club = findClubOrThrow(clubId)
 

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
@@ -37,6 +37,15 @@ public class ClubLikeService {
     }
 */
 /*
+    public ClubLikeResponseDto getClubLikeCount(Long clubId, Long memberId) {
+        Club club = findClubOrThrow(clubId);
+        boolean isLiked = (memberId != null) && clubLikeRepository.existsByClubIdAndMemberId(club.getId(), memberId);
+        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
+
+        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+    }
+*/
+/*
 
     private Member findMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
@@ -1,6 +1,8 @@
 package com.mobble.mobbleserver.domain.like.clubLike.service;
 
+import com.mobble.mobbleserver.domain.like.clubLike.dto.response.ClubLikeResponseDto;
 import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
+import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,47 +17,43 @@ public class ClubLikeService {
 //    private final ClubRepository clubRepository;
     private final ClubLikeRepository clubLikeRepository;
 
-/*
     @Transactional
     public ClubLikeResponseDto toggleLike(Long clubId, Long memberId) {
         Member member = findMemberOrThrow(memberId);
 //        Club club = findClubOrThrow(clubId)
-
-        Optional<ClubLike> checkLiked = clubLikeRepository.findLikedByClubIdAndMemberId(club.getId(), member.getId());
-
-        if (checkLiked.isPresent()) {
-            clubLikeRepository.delete(checkLiked.get());
-        } else {
-            ClubLike clubLike = ClubLike.createClubLike(club, member);
-            clubLikeRepository.save(clubLike);
-        }
-
-        boolean isLiked = checkLiked.isEmpty();
-        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
-
-        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+//
+//        Optional<ClubLike> checkLiked = clubLikeRepository.findLikedByClubIdAndMemberId(club.getId(), member.getId());
+//
+//        if (checkLiked.isPresent()) {
+//            clubLikeRepository.delete(checkLiked.get());
+//        } else {
+//            ClubLike clubLike = ClubLike.createClubLike(club, member);
+//            clubLikeRepository.save(clubLike);
+//        }
+//
+//        boolean isLiked = checkLiked.isEmpty();
+//        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
+//
+//        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+        return null;
     }
-*/
-/*
+
     public ClubLikeResponseDto getClubLikeCount(Long clubId, Long memberId) {
-        Club club = findClubOrThrow(clubId);
-        boolean isLiked = (memberId != null) && clubLikeRepository.existsByClubIdAndMemberId(club.getId(), memberId);
-        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
-
-        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+//        Club club = findClubOrThrow(clubId);
+//        boolean isLiked = (memberId != null) && clubLikeRepository.existsByClubIdAndMemberId(club.getId(), memberId);
+//        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
+//
+//        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+        return null;
     }
-*/
-/*
 
     private Member findMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("")); // Todo: Custom 예외 적용
     }
-*/
-/*
-    private Club findClubOrThrow(Long clubId) {
-        return clubRepository.findById(clubId)
-                .orElseThrow(() -> new IllegalArgumentException(""));
-    }
-*/
+
+//    private Club findClubOrThrow(Long clubId) {
+//        return clubRepository.findById(clubId)
+//                .orElseThrow(() -> new IllegalArgumentException(""));
+//    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeService.java
@@ -1,0 +1,52 @@
+package com.mobble.mobbleserver.domain.like.clubLike.service;
+
+import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
+import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubLikeService {
+
+    private final MemberRepository memberRepository;
+//    private final ClubRepository clubRepository;
+    private final ClubLikeRepository clubLikeRepository;
+
+/*
+    @Transactional
+    public ClubLikeResponseDto toggleLike(@Positive Long clubId, Long memberId) {
+        Member member = findMemberOrThrow(memberId);
+//        Club club = findClubOrThrow(clubId)
+
+        Optional<ClubLike> checkLiked = clubLikeRepository.findLikedByClubIdAndMemberId(club.getId(), member.getId());
+
+        if (checkLiked.isPresent()) {
+            clubLikeRepository.delete(checkLiked.get());
+        } else {
+            ClubLike clubLike = ClubLike.createClubLike(club, member);
+            clubLikeRepository.save(clubLike);
+        }
+
+        boolean isLiked = checkLiked.isEmpty();
+        int likeCount = clubLikeRepository.countClubLikesByClubId(club.getId());
+
+        return ClubLikeResponseDto.toDto(club.getId(), isLiked, likeCount);
+    }
+*/
+/*
+
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("")); // Todo: Custom 예외 적용
+    }
+*/
+/*
+    private Club findClubOrThrow(Long clubId) {
+        return clubRepository.findById(clubId)
+                .orElseThrow(() -> new IllegalArgumentException(""));
+    }
+*/
+}


### PR DESCRIPTION
## 📄 클럽 좋아요 기능 구현
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #31 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- 클럽 좋아요(toggle) & likeCount 조회 기능 구현
- likeCount 조회 메서드 구현
- 서비스 로직 내 중복 검증 메서드 분리 (member, club)

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->
- club 도메인 미비로 서비스레이어 주석처리

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- 추후 club 구현 후 주석 해제 및 테스트 예정
- member, club 검증로직 리팩토링 필요 (validator)