### PR TITLE
Feature/member soft delete

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/MobbleServerApplication.java
+++ b/src/main/java/com/mobble/mobbleserver/MobbleServerApplication.java
@@ -3,7 +3,9 @@ package com.mobble.mobbleserver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MobbleServerApplication {

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberDeleteScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberDeleteScheduler.java
@@ -26,7 +26,7 @@ public class MemberDeleteScheduler {
         LocalDateTime withdrewDate = LocalDateTime.now().minusDays(7);
         log.info("withdrew members delete time: {}", withdrewDate);
 
-        List<Member> withdrewMembers = memberRepository.findByIsDeletedTrueAndDeletedAtBefore(withdrewDate);
+        List<Member> withdrewMembers = memberRepository.findAllByIsDeletedTrueAndDeletedAtBefore(withdrewDate);
 
         if (withdrewMembers.isEmpty()) {
             log.info("Not found withdrew members to delete");

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberDeleteScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberDeleteScheduler.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class MemberScheduler {
+public class MemberDeleteScheduler {
 
     private final MemberRepository memberRepository;
 

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
@@ -3,6 +3,7 @@ package com.mobble.mobbleserver.domain.member.Scheduler;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberScheduler {
@@ -19,10 +21,19 @@ public class MemberScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void deleteWithdrewMembers() {
+        log.info("Delete the withdrew members.");
 
         LocalDateTime withdrewDate = LocalDateTime.now().minusDays(7);
+        log.info("withdrew members delete time: {}", withdrewDate);
+
         List<Member> withdrewMembers = memberRepository.findWithdrewMembers(withdrewDate);
 
+        if (withdrewMembers.isEmpty()) {
+            log.info("Not found withdrew members to delete");
+        }
+        log.info("Deleting {} withdrew members.", withdrewMembers.size());
+
         memberRepository.deleteAll(withdrewMembers);
+        log.info("Finished deleting withdrew members.");
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
@@ -1,0 +1,26 @@
+package com.mobble.mobbleserver.domain.member.Scheduler;
+
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MemberScheduler {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void deleteWithdrewMembers() {
+
+        LocalDateTime withdrewDate = LocalDateTime.now().minusDays(7);
+        List<Member> withdrewMembers = memberRepository.findWithdrewMembers(withdrewDate);
+
+        memberRepository.deleteAll(withdrewMembers);
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
@@ -26,7 +26,7 @@ public class MemberScheduler {
         LocalDateTime withdrewDate = LocalDateTime.now().minusDays(7);
         log.info("withdrew members delete time: {}", withdrewDate);
 
-        List<Member> withdrewMembers = memberRepository.findWithdrewMembers(withdrewDate);
+        List<Member> withdrewMembers = memberRepository.findByIsDeletedTrueAndDeletedAtBefore(withdrewDate);
 
         if (withdrewMembers.isEmpty()) {
             log.info("Not found withdrew members to delete");

--- a/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/Scheduler/MemberScheduler.java
@@ -3,6 +3,7 @@ package com.mobble.mobbleserver.domain.member.Scheduler;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ public class MemberScheduler {
 
     private final MemberRepository memberRepository;
 
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void deleteWithdrewMembers() {
 

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -6,12 +6,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -6,14 +6,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("is_deleted = false")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -126,4 +126,9 @@ public class Member extends BaseEntity {
         this.profileImage = profileImage;
         return this;
     }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,17 +19,23 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
+    @Column(name = "name")
     private String name;
 
+    @Column(name = "age")
     private int age;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
     private Gender gender;
 
+    @Column(name = "email")
     private String email;
 
+    @Column(name = "phone")
     private String phone;
 
+    @Column(name = "ground")
     private String ground;
 
     @Column(name = "profile_image")
@@ -48,6 +56,9 @@ public class Member extends BaseEntity {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Member(
             String name,
@@ -58,7 +69,8 @@ public class Member extends BaseEntity {
             String ground,
             String profileImage,
             boolean termsAgreed,
-            boolean privacyAgreed
+            boolean privacyAgreed,
+            boolean isDeleted
 //            SocialProvider socialProvider,
 //            String socialId,
     ) {
@@ -71,6 +83,7 @@ public class Member extends BaseEntity {
         this.profileImage = profileImage;
         this.termsAgreed = termsAgreed;
         this.privacyAgreed = privacyAgreed;
+        this.isDeleted = isDeleted;
 //        this.socialProvider = socialProvider;
 //        this.socialId = socialId;
     }
@@ -102,6 +115,7 @@ public class Member extends BaseEntity {
                 .profileImage(profileImage)
                 .termsAgreed(termsAgreed)
                 .privacyAgreed(privacyAgreed)
+                .isDeleted(false)
 //                .socialProvider(socialProvider)
 //                .socialId(socialId)
                 .build();

--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -2,13 +2,34 @@ package com.mobble.mobbleserver.domain.member.repository;
 
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    boolean existsByEmail(String email);
+    /**
+     * isDeleted = true 포함 멤버 유무 조회
+     * @param email
+     * @return
+     */
+    @Query(value = "SELECT * FROM member m " +
+            "WHERE m.email = :email",
+            nativeQuery = true)
+    Optional<Member> findMemberByEmail(@Param("email") String email);
 
-    List<Member> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime withdrewDate);
+    /**
+     * softDelete 멤버 조회
+     * @param withdrewDate
+     * @return
+     */
+    @Query(value =
+            "SELECT * FROM member " +
+                    "WHERE is_deleted = true " +
+                    "AND deleted_at < :withdrewDate",
+            nativeQuery = true)
+    List<Member> findByIsDeletedTrueAndDeletedAtBefore(@Param("withdrewDate") LocalDateTime withdrewDate);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -10,5 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
-    List<Member> findWithdrewMembers(LocalDateTime withdrewDate);
+    List<Member> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime withdrewDate);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -2,8 +2,6 @@ package com.mobble.mobbleserver.domain.member.repository;
 
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,25 +9,10 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    /**
-     * isDeleted = true 포함 멤버 유무 조회
-     * @param email
-     * @return
-     */
-    @Query(value = "SELECT * FROM member m " +
-            "WHERE m.email = :email",
-            nativeQuery = true)
-    Optional<Member> findMemberByEmail(@Param("email") String email);
+    // 활성 회원(isDeleted = false)만 조회하는 메소드
+    Optional<Member> findByIdAndIsDeletedFalse(Long memberId);
 
-    /**
-     * softDelete 멤버 조회
-     * @param withdrewDate
-     * @return
-     */
-    @Query(value =
-            "SELECT * FROM member " +
-                    "WHERE is_deleted = true " +
-                    "AND deleted_at < :withdrewDate",
-            nativeQuery = true)
-    List<Member> findByIsDeletedTrueAndDeletedAtBefore(@Param("withdrewDate") LocalDateTime withdrewDate);
+    // soft-delete(isDeleted = true) 회원을 포함한 모든 회원 조회
+    Optional<Member> findByEmail(String email);
+    List<Member> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime withdrewDate);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -3,7 +3,12 @@ package com.mobble.mobbleserver.domain.member.repository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
+
+    List<Member> findWithdrewMembers(LocalDateTime withdrewDate);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -12,7 +12,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 활성 회원(isDeleted = false)만 조회하는 메소드
     Optional<Member> findByIdAndIsDeletedFalse(Long memberId);
 
+    boolean existsByEmail(String email);
+
     // soft-delete(isDeleted = true) 회원을 포함한 모든 회원 조회
-    Optional<Member> findByEmail(String email);
     List<Member> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime withdrewDate);
+
+    boolean existsByEmailAndIsDeletedTrue(String email);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
@@ -21,7 +21,7 @@ public class MemberService {
 
     @Transactional
     public MemberCreateResponseDto createMember(MemberCreateRequestDto dto) {
-        memberRepository.existsByEmail(dto.email());
+        memberValidator.validateEmailDuplication(dto.email());
         Member member = memberRepository.save(dto.toEntity());
 
         return MemberCreateResponseDto.toDto(member);

--- a/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
@@ -21,7 +21,8 @@ public class MemberService {
 
     @Transactional
     public MemberCreateResponseDto createMember(MemberCreateRequestDto dto) {
-        memberValidator.validateEmailDuplication(dto.email());
+        memberValidator.exitsEmailOrThrow(dto.email());
+        memberValidator.exitsWithdrewEmailOrThrow(dto.email());
         Member member = memberRepository.save(dto.toEntity());
 
         return MemberCreateResponseDto.toDto(member);

--- a/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
@@ -44,6 +44,6 @@ public class MemberService {
     @Transactional
     public void deleteMember(Long memberId) {
         Member member = memberValidator.findMemberOrThrow(memberId);
-        memberRepository.delete(member);
+        member.softDelete();
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -16,12 +16,13 @@ public class MemberValidator {
     private final MemberRepository memberRepository;
 
     public Member findMemberOrThrow(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdAndIsDeletedFalse(memberId)
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
+    // Todo 분리
     public void validateEmailDuplication(String email) {
-        Optional<Member> checkMember = memberRepository.findMemberByEmail(email);
+        Optional<Member> checkMember = memberRepository.findByEmail(email);
         if (checkMember.isPresent()) {
             Member member = checkMember.get();
             if (member.isDeleted()) {

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -7,6 +7,8 @@ import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class MemberValidator {
@@ -16,5 +18,17 @@ public class MemberValidator {
     public Member findMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    public void validateEmailDuplication(String email) {
+        Optional<Member> checkMember = memberRepository.findMemberByEmail(email);
+        if (checkMember.isPresent()) {
+            Member member = checkMember.get();
+            if (member.isDeleted()) {
+                throw new IllegalArgumentException("");
+            } else {
+                throw new IllegalArgumentException("");
+            }
+        }
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -7,8 +7,6 @@ import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Component
 @RequiredArgsConstructor
 public class MemberValidator {
@@ -20,16 +18,15 @@ public class MemberValidator {
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
-    // Todo 분리
-    public void validateEmailDuplication(String email) {
-        Optional<Member> checkMember = memberRepository.findByEmail(email);
-        if (checkMember.isPresent()) {
-            Member member = checkMember.get();
-            if (member.isDeleted()) {
-                throw new IllegalArgumentException("");
-            } else {
-                throw new IllegalArgumentException("");
-            }
+    public void exitsEmailOrThrow(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("");
+        }
+    }
+
+    public void exitsWithdrewEmailOrThrow(String email) {
+        if (memberRepository.existsByEmailAndIsDeletedTrue(email)) {
+            throw new IllegalArgumentException("");
         }
     }
 }


### PR DESCRIPTION
## 📄 scheduler 회원 탈퇴 기능 구현
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #53 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- Member 엔티티 deletedAt 필드 추가, 필드 전체 @Column 적용
- @SQLRestriction 적용 isDeleted = true 데이터 조회 차단
- MemberScheduler 구현, 회원 탈퇴시 일정 기간 유지 후 hard delete
- hard delete 전까지 재가입 불가능
- 검증 로직 validator 메서드로 구현

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- scheduler 실행시 log 출력
- QueryDSL 도입 고려