### PR TITLE
Feature/chat entity

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/entity/ChatMessage.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/entity/ChatMessage.java
@@ -1,0 +1,63 @@
+package com.mobble.mobbleserver.domain.chat.chatMessage.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "chat_message_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private MessageType type;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ChatMessage(
+            ChatRoom chatRoom,
+            Member sender,
+            String content,
+            MessageType type
+    ) {
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.content = content;
+        this.type = type;
+    }
+
+    public static ChatMessage createChatMessage(
+            ChatRoom chatRoom,
+            Member sender,
+            String content,
+            MessageType type
+    ) {
+        return ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .content(content)
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/entity/MessageType.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/entity/MessageType.java
@@ -1,0 +1,5 @@
+package com.mobble.mobbleserver.domain.chat.chatMessage.entity;
+
+public enum MessageType {
+    TEXT
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessage/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.chatMessage.repository;
+
+import com.mobble.mobbleserver.domain.chat.chatMessage.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/entity/ChatMessageMention.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/entity/ChatMessageMention.java
@@ -1,0 +1,41 @@
+package com.mobble.mobbleserver.domain.chat.chatMessageMention.entity;
+
+import com.mobble.mobbleserver.domain.chat.chatMessage.entity.ChatMessage;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageMention {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "chat_message_mention_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id", nullable = false)
+    private ChatMessage chatMessage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentioned_member_id", nullable = false)
+    private Member mentionedMember;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ChatMessageMention(ChatMessage chatMessage, Member mentionedMember) {
+        this.chatMessage = chatMessage;
+        this.mentionedMember = mentionedMember;
+    }
+
+    public static ChatMessageMention createChatMessageMention(ChatMessage chatMessage, Member mentionedMember) {
+        return ChatMessageMention.builder()
+                .chatMessage(chatMessage)
+                .mentionedMember(mentionedMember)
+                .build();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/entity/ChatMessageMention.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/entity/ChatMessageMention.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.chat.chatMessageMention.entity;
 
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
 import com.mobble.mobbleserver.domain.chat.chatMessage.entity.ChatMessage;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -11,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Entity
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatMessageMention {
+public class ChatMessageMention extends CreatedAtEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/repository/ChatMessageMentionRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatMessageMention/repository/ChatMessageMentionRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.chatMessageMention.repository;
+
+import com.mobble.mobbleserver.domain.chat.chatMessageMention.entity.ChatMessageMention;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageMentionRepository extends JpaRepository<ChatMessageMention, Long> {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/entity/ChatRoom.java
@@ -1,0 +1,34 @@
+package com.mobble.mobbleserver.domain.chat.chatRoom.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private ChatRoomType type;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ChatRoom(ChatRoomType type) {
+        this.type = type;
+    }
+
+    public static ChatRoom createChatRoom(ChatRoomType type) {
+        return ChatRoom.builder()
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/entity/ChatRoomType.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/entity/ChatRoomType.java
@@ -1,0 +1,6 @@
+package com.mobble.mobbleserver.domain.chat.chatRoom.entity;
+
+public enum ChatRoomType {
+    GROUP,
+    DIRECT;
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoom/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.chatRoom.repository;
+
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoomParticipant/entity/ChatRoomParticipant.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoomParticipant/entity/ChatRoomParticipant.java
@@ -1,0 +1,62 @@
+package com.mobble.mobbleserver.domain.chat.chatRoomParticipant.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
+import com.mobble.mobbleserver.domain.chat.chatMessage.entity.ChatMessage;
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomParticipant extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_participant_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_read_message_id")
+    private ChatMessage lastReadMessage;
+
+    @Column(name = "notified", nullable = false)
+    private boolean notified = true;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public ChatRoomParticipant(ChatRoom chatRoom, Member member) {
+        this.chatRoom = chatRoom;
+        this.member = member;
+    }
+
+    public static ChatRoomParticipant createChatRoomParticipant(ChatRoom chatRoom, Member member) {
+        return ChatRoomParticipant.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .build();
+    }
+
+    public void updateLastReadMessage(ChatMessage chatMessage) {
+        this.lastReadMessage = chatMessage;
+    }
+
+    public void enableNotified() {
+        this.notified = true;
+    }
+
+    public void disableNotified() {
+        this.notified = false;
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoomParticipant/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/chatRoomParticipant/repository/ChatRoomParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.chatRoomParticipant.repository;
+
+import com.mobble.mobbleserver.domain.chat.chatRoomParticipant.entity.ChatRoomParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
@@ -1,0 +1,41 @@
+package com.mobble.mobbleserver.domain.chat.clubChatRoom.entity;
+
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.club.entity.Club;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_chat_room_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false, unique = true)
+    private Club club;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false, unique = true)
+    private ChatRoom chatRoom;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public ClubChatRoom(Club club, ChatRoom chatRoom) {
+        this.club = club;
+        this.chatRoom = chatRoom;
+    }
+
+    public static ClubChatRoom createClubChatRoom(Club club, ChatRoom chatRoom) {
+        return ClubChatRoom.builder()
+                .club(club)
+                .chatRoom(chatRoom)
+                .build();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
@@ -27,7 +27,7 @@ public class ClubChatRoom {
     private ChatRoom chatRoom;
 
     @Builder(access = AccessLevel.PRIVATE)
-    public ClubChatRoom(Club club, ChatRoom chatRoom) {
+    private ClubChatRoom(Club club, ChatRoom chatRoom) {
         this.club = club;
         this.chatRoom = chatRoom;
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
@@ -1,7 +1,7 @@
 package com.mobble.mobbleserver.domain.chat.clubChatRoom.repository;
 
-import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClubChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ClubChatRoomRepository extends JpaRepository<ClubChatRoom, Long> {
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.clubChatRoom.repository;
+
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/directChatRoom/entity/DirectChatRoom.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/directChatRoom/entity/DirectChatRoom.java
@@ -1,0 +1,51 @@
+package com.mobble.mobbleserver.domain.chat.directChatRoom.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class DirectChatRoom extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "direct_chat_room_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false, unique = true)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_a_id", nullable = false)
+    private Member memberA;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_b_id", nullable = false)
+    private Member memberB;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private DirectChatRoom(ChatRoom chatRoom, Member memberA, Member memberB) {
+        this.chatRoom = chatRoom;
+        this.memberA = memberA;
+        this.memberB = memberB;
+    }
+
+    public static DirectChatRoom createDirectChatRoom(ChatRoom chatRoom, Member memberA, Member memberB) {
+        Member a = memberA.getId() < memberB.getId() ? memberA : memberB;
+        Member b = memberA.getId() < memberB.getId() ? memberB : memberA;
+
+        return DirectChatRoom.builder()
+                .chatRoom(chatRoom)
+                .memberA(a)
+                .memberB(b)
+                .build();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/directChatRoom/repository/DirectChatRoomRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/directChatRoom/repository/DirectChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.chat.directChatRoom.repository;
+
+import com.mobble.mobbleserver.domain.chat.directChatRoom.entity.DirectChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectChatRoomRepository extends JpaRepository<DirectChatRoom, Long> {
+}


### PR DESCRIPTION
## 📄 feat: 실시간 채팅 도메인 및 기본 JPA 레포지토리 구현

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #83 

## ✅ 변경 사항
- 실시간 채팅 도메인 엔티티 6종 구현 (ChatRoom, DirectChatRoom, ClubChatRoom, ChatRoomParticipant, ChatMessage, ChatMessageMention)
- 각 엔티티에 대한 JPA Repository 인터페이스 생성

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->

## 📝 기타 사항
- 추후 메시지 전송, 소켓 통신 등 기능 개발에 맞춰 도메인 확장 예정
