### PR TITLE
Feature/notification entity

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/notification/entity/Notification.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/notification/entity/Notification.java
@@ -1,0 +1,71 @@
+package com.mobble.mobbleserver.domain.notification.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends CreatedAtEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private NotificationType type;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "is_read")
+    private boolean isRead;
+
+    @Column(name = "related")
+    private Long related;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Notification(
+            Member receiver,
+            NotificationType type,
+            String content,
+            boolean isRead,
+            Long related
+    ) {
+        this.receiver = receiver;
+        this.type = type;
+        this.content = content;
+        this.isRead = isRead;
+        this.related = related;
+    }
+
+    public Notification createNotification(
+            Member receiver,
+            NotificationType type,
+            String content,
+            Long related
+    ) {
+        return Notification.builder()
+                .receiver(receiver)
+                .type(type)
+                .content(content)
+                .isRead(false)
+                .related(related)
+                .build();
+    }
+
+    public void marksAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/notification/entity/NotificationType.java
@@ -1,0 +1,4 @@
+package com.mobble.mobbleserver.domain.notification.entity;
+
+public enum NotificationType {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.mobble.mobbleserver.domain.notification.repository;
+
+import com.mobble.mobbleserver.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}


### PR DESCRIPTION
## 📄 feat: 알림(Notification) 엔티티 및 레포지토리 생성

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #86 

## ✅ 변경 사항
- Notification 엔티티 생성 (알림 수신자, 타입, 내용, 읽음 여부, 관련 대상 ID 포함)
- NotificationType enum 정의 (타입별 알림을 구분하기 위한 구조)
- NotificationRepository 인터페이스 생성 (JPA 기반)
- 읽음 상태 변경을 위한 markAsRead() 메서드 구현

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인
