### PR TITLE
Feature/util timestamp

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/global/exception/handler/dto/ErrorResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/global/exception/handler/dto/ErrorResponseDto.java
@@ -1,10 +1,8 @@
 package com.mobble.mobbleserver.global.exception.handler.dto;
 
 import com.mobble.mobbleserver.global.exception.common.ErrorCode;
+import com.mobble.mobbleserver.util.DateTimeUtils;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public record ErrorResponseDto(
@@ -18,7 +16,7 @@ public record ErrorResponseDto(
     // Validation or Binding Error
     public static ErrorResponseDto toDto(ErrorCode errorCode, Map<String, String> errors) {
         return new ErrorResponseDto(
-                createDateTime(),
+                DateTimeUtils.now(),
                 errorCode.message(),
                 errorCode.httpStatus().value(),
                 errorCode.httpStatus().name(),
@@ -29,16 +27,11 @@ public record ErrorResponseDto(
     // Global or Domain Error
     public static ErrorResponseDto toDto(ErrorCode errorCode) {
         return new ErrorResponseDto(
-                createDateTime(),
+                DateTimeUtils.now(),
                 errorCode.message(),
                 errorCode.httpStatus().value(),
                 errorCode.httpStatus().name(),
                 null
         );
-    }
-
-    private static String createDateTime() {
-        return ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
-                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/util/DateTimeUtils.java
+++ b/src/main/java/com/mobble/mobbleserver/util/DateTimeUtils.java
@@ -1,0 +1,25 @@
+package com.mobble.mobbleserver.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public enum DateTimeUtils {
+    ;
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    public static String now() {
+        return ZonedDateTime.now(ZONE_ID)
+                .format(FORMATTER);
+    }
+
+    public static String format(LocalDateTime dateTime) {
+        return dateTime
+                .atZone(ZoneId.systemDefault())
+                .withZoneSameInstant(ZONE_ID)
+                .format(FORMATTER);
+    }
+}


### PR DESCRIPTION
## 📄 refactor: DateTimeUtils 유틸리티 클래스를 enum 기반으로 구현

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #89 

## ✅ 변경 사항
- 공통 시간 처리 유틸리티 DateTimeUtils를 열거형 기반으로 구현하여 인스턴스화 방지
- 현재 시각을 한국 시간 기준 ISO 형식으로 반환하는 now() 메서드 추가
- LocalDateTime을 한국 시간 기준 ISO 형식으로 변환하는 format(LocalDateTime) 메서드 추가
- 기존 코드 내 시간 처리 로직 일부를 DateTimeUtils 유틸 메서드로 교체

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분


## 📝 기타 사항
- enum 방식은 클래스 기반보다 인스턴스화를 보다 강하게 방지할 수 있어 안정적
- 시간 포맷은 ISO_OFFSET_DATE_TIME 기준으로 통일되어 응답 포맷이 일관됨
- 추후 ZonedDateTime, Instant 포맷 메서드가 필요할 경우 오버로딩으로 확장 가능
