### PR TITLE
Refactor/move leader validation to entity

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/club/service/ClubService.java
@@ -83,7 +83,7 @@ public class ClubService {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
-        clubMember.assertLeaderOrThrow();
+        clubMember.assertLeader();
 
         ClubCategory category = findCategoryOrThrow(dto.category());
         club.updateClub(category, dto.name(), dto.ground(), dto.address(), dto.headcount(), dto.isAutoJoin());
@@ -100,7 +100,7 @@ public class ClubService {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
-        clubMember.assertLeaderOrThrow();
+        clubMember.assertLeader();
 
         clubLikeRepository.deleteClubLikeAllByClub_Id(clubId);
 

--- a/src/main/java/com/mobble/mobbleserver/domain/club/club/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/club/service/ClubService.java
@@ -2,14 +2,14 @@ package com.mobble.mobbleserver.domain.club.club.service;
 
 import com.mobble.mobbleserver.domain.article.repository.ArticleRepository;
 import com.mobble.mobbleserver.domain.club.club.dto.request.ClubRequestDto;
+import com.mobble.mobbleserver.domain.club.club.dto.response.ClubResponseDto;
 import com.mobble.mobbleserver.domain.club.club.entity.Club;
 import com.mobble.mobbleserver.domain.club.club.repository.ClubRepository;
-import com.mobble.mobbleserver.domain.club.clubAgeGroup.entity.ClubAgeGroupType;
-import com.mobble.mobbleserver.domain.club.clubAgeGroup.repository.ClubAgeGroupRepository;
-import com.mobble.mobbleserver.domain.club.club.dto.response.ClubResponseDto;
 import com.mobble.mobbleserver.domain.club.club.repository.dto.ClubLikeInfoDto;
 import com.mobble.mobbleserver.domain.club.club.validator.ClubValidator;
 import com.mobble.mobbleserver.domain.club.clubAgeGroup.entity.ClubAgeGroup;
+import com.mobble.mobbleserver.domain.club.clubAgeGroup.entity.ClubAgeGroupType;
+import com.mobble.mobbleserver.domain.club.clubAgeGroup.repository.ClubAgeGroupRepository;
 import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
 import com.mobble.mobbleserver.domain.clubCategory.repository.ClubCategoryRepository;
 import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
@@ -25,7 +25,6 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,8 +49,6 @@ public class ClubService {
     private final ClubValidator clubValidator;
     private final MemberValidator memberValidator;
     private final ClubMemberValidator clubMemberValidator;
-
-    private final EntityManager entityManager;
 
     @Transactional
     public ClubResponseDto createClub(Long memberId, ClubRequestDto dto) {
@@ -85,7 +82,8 @@ public class ClubService {
     public ClubResponseDto updateClub(Long clubId, Long memberId, ClubRequestDto dto) {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
-        validateLeader(clubId, memberId);
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        clubMember.assertLeaderOrThrow();
 
         ClubCategory category = findCategoryOrThrow(dto.category());
         club.updateClub(category, dto.name(), dto.ground(), dto.address(), dto.headcount(), dto.isAutoJoin());
@@ -101,7 +99,8 @@ public class ClubService {
     public void deleteClub(Long clubId, Long memberId) {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
-        validateLeader(clubId, memberId);
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        clubMember.assertLeaderOrThrow();
 
         clubLikeRepository.deleteClubLikeAllByClub_Id(clubId);
 
@@ -122,14 +121,6 @@ public class ClubService {
     private ClubCategory findCategoryOrThrow(String categoryName) {
         return clubCategoryRepository.findByName(categoryName)
                 .orElseThrow(() -> new DomainException(ClubErrorCode.CATEGORY_NOT_FOUND));
-    }
-
-    private void validateLeader(Long clubId, Long memberId) {
-        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
-
-        if (!clubMember.getClubMemberRole().equals(ClubMemberRole.LEADER)) {
-            throw new DomainException(ClubErrorCode.NO_PERMISSION);
-        }
     }
 
     private ClubResponseDto buildClubResponse(Club club, Member member, String leaderName) {

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/controller/ClubMemberController.java
@@ -52,7 +52,7 @@ public class ClubMemberController {
         Long loginedMemberId = 2L; // Todo: 임시 member id
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(clubMemberService.updateClubMemberStatus(clubId, loginedMemberId, dto));
+                .body(clubMemberService.updateClubMemberJoinStatus(clubId, loginedMemberId, dto));
     }
 
     @PatchMapping("/{club-id}/members/role")

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
@@ -73,7 +73,7 @@ public class ClubMember extends BaseEntity {
         this.clubMemberRole = newRole;
     }
 
-    public void assertLeaderOrThrow() {
+    public void assertLeader() {
         if (this.clubMemberRole != ClubMemberRole.LEADER) {
             throw new DomainException(ClubMemberErrorCode.NO_PERMISSION);
         }

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
@@ -5,6 +5,7 @@ import com.mobble.mobbleserver.domain.club.club.entity.Club;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -74,7 +75,7 @@ public class ClubMember extends BaseEntity {
 
     public void assertLeaderOrThrow() {
         if (this.clubMemberRole != ClubMemberRole.LEADER) {
-            throw new DomainException(ClubErrorCode.NO_PERMISSION);
+            throw new DomainException(ClubMemberErrorCode.NO_PERMISSION);
         }
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMember.java
@@ -1,9 +1,10 @@
 package com.mobble.mobbleserver.domain.clubMember.entity;
 
 import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
-import com.mobble.mobbleserver.common.baseEntity.CreatedAtEntity;
 import com.mobble.mobbleserver.domain.club.club.entity.Club;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -69,5 +70,11 @@ public class ClubMember extends BaseEntity {
 
     public void updateRole(ClubMemberRole newRole) {
         this.clubMemberRole = newRole;
+    }
+
+    public void assertLeaderOrThrow() {
+        if (this.clubMemberRole != ClubMemberRole.LEADER) {
+            throw new DomainException(ClubErrorCode.NO_PERMISSION);
+        }
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
@@ -14,7 +14,6 @@ import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
-import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -74,8 +73,8 @@ public class ClubMemberService {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(targetMemberId);
         Member loginedMember = memberValidator.findMemberByMemberIdOrThrow(loginedMemberId);
-
-        validateLeader(club.getId(), loginedMember.getId());
+        ClubMember clubLeader = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, loginedMember.getId());
+        clubLeader.assertLeaderOrThrow();
 
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, targetMemberId);
 
@@ -96,8 +95,8 @@ public class ClubMemberService {
         Club club = clubValidator.findClubByClubIdOrThrow(clubId);
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
         Member loginedMember = memberValidator.findMemberByMemberIdOrThrow(loginedMemberId);
-
-        validateLeader(club.getId(), loginedMember.getId());
+        ClubMember clubLeader = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, loginedMember.getId());
+        clubLeader.assertLeaderOrThrow();
 
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, member.getId());
 
@@ -118,14 +117,6 @@ public class ClubMemberService {
         return clubMembers.stream()
                 .map(ClubMemberResponseDto::toEntity)
                 .collect(Collectors.toList());
-    }
-
-    private void validateLeader(Long clubId, Long memberId) {
-        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
-
-        if (!clubMember.getClubMemberRole().equals(ClubMemberRole.LEADER)) {
-            throw new DomainException(ClubErrorCode.NO_PERMISSION);
-        }
     }
 
     private JoinStatus determineJoinStatus(Club club) {

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
@@ -87,7 +87,7 @@ public class ClubMemberService {
     }
 
     @Transactional
-    public ClubMemberUpsertResponseDto updateClubMemberStatus(Long clubId, Long loginedMemberId,
+    public ClubMemberUpsertResponseDto updateClubMemberJoinStatus(Long clubId, Long loginedMemberId,
                                                               UpdateClubMemberStatusDto dto) {
         Long memberId = dto.memberId();
         JoinStatus targetStatus = dto.status();

--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberService.java
@@ -74,7 +74,7 @@ public class ClubMemberService {
         Member member = memberValidator.findMemberByMemberIdOrThrow(targetMemberId);
         Member loginedMember = memberValidator.findMemberByMemberIdOrThrow(loginedMemberId);
         ClubMember clubLeader = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, loginedMember.getId());
-        clubLeader.assertLeaderOrThrow();
+        clubLeader.assertLeader();
 
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, targetMemberId);
 
@@ -96,7 +96,7 @@ public class ClubMemberService {
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
         Member loginedMember = memberValidator.findMemberByMemberIdOrThrow(loginedMemberId);
         ClubMember clubLeader = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, loginedMember.getId());
-        clubLeader.assertLeaderOrThrow();
+        clubLeader.assertLeader();
 
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, member.getId());
 

--- a/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/club/ClubErrorCode.java
+++ b/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/club/ClubErrorCode.java
@@ -13,8 +13,7 @@ public enum ClubErrorCode implements ErrorCode {
     GROUND_REQUIRED("클럽 활동지역은 필수 입니다.", HttpStatus.BAD_REQUEST),
     ADDRESS_REQUIRED("클럽 주소는 필수 입니다.", HttpStatus.BAD_REQUEST),
     HEADCOUNT_REQUIRED("클럽 정원 수는 2명 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
-    CATEGORY_NOT_FOUND("알수 없는 클럽 카테고리입니다.", HttpStatus.BAD_REQUEST),
-    NO_PERMISSION("해당 클럽을 수정 또는 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    CATEGORY_NOT_FOUND("알수 없는 클럽 카테고리입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/club/ClubMemberErrorCode.java
+++ b/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/club/ClubMemberErrorCode.java
@@ -10,7 +10,8 @@ public enum ClubMemberErrorCode implements ErrorCode {
     ALREADY_JOINED("이미 해당 클럽에 가입 또는 신청 된 상태입니다.", HttpStatus.CONFLICT),
     NOT_JOINED_CLUB("해당 클럽에 가입된 회원이 아닙니다.", HttpStatus.FORBIDDEN),
     CLUB_IS_FULL("클럽 정원이 초과되어 가입 할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    CANNOT_CHANGE_OWN_ROLE("본인의 권한은 변경 할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    CANNOT_CHANGE_OWN_ROLE("본인의 권한은 변경 할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NO_PERMISSION("수정 또는 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String message;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📄 ClubMember Entity에서 클럽 리더 검증 하도록 수정

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #98 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ClubMember Entity에 클럽 리더 검증 메서드 추가
- ClubService, ClubMemberService 에서 기존 검즘 메서드 삭제 후 Entity 메서드 사용 
- NO_PERMISSION 에러코드 ClubMemberErrorCode로 옮김

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
Entity말고 ClubMemberValidator 에서 검증 하는건 어떨까요?
