### PR TITLE
Feature/meeting crud

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -51,7 +51,7 @@ public class MeetingController {
                 .body(meetingService.findMeetingById(meetingId, memberId));
     }
 
-    @PatchMapping("/api/meetings/{meeting-id}")
+    @PatchMapping("/api/clubs/{club-id}/meetings/{meeting-id}")
     public ResponseEntity<MeetingResponseDto> updateMeeting(
             @PathVariable("meeting-id") @Positive Long meetingId,
             @RequestBody MeetingUpdateRequestDto dto
@@ -61,7 +61,7 @@ public class MeetingController {
                 .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
 
-    @DeleteMapping("/api/meetings/{meeting-id}")
+    @DeleteMapping("/api/clubs/{club-id}/meetings/{meeting-id}")
     public ResponseEntity<Void> deleteMeeting(
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -60,4 +60,14 @@ public class MeetingController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
+
+    @DeleteMapping("/api/meetings/{meeting-id}")
+    public ResponseEntity<Void> deleteMeeting(
+            @PathVariable("meeting-id") @Positive Long meetingId
+    ) {
+        Long memberId = 1L;
+        meetingService.deleteMeeting(memberId, meetingId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -16,11 +16,12 @@ import java.util.List;
 @Validated
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/clubs/{club-id}/meetings")
 public class MeetingController {
 
     private final MeetingService meetingService;
 
-    @PostMapping("/api/clubs/{club-id}/meetings")
+    @PostMapping
     public ResponseEntity<MeetingResponseDto> createMeeting(
             @PathVariable("club-id") @Positive Long clubId,
             @RequestBody MeetingRequestDto dto
@@ -31,7 +32,7 @@ public class MeetingController {
                 .body(meetingService.createMeeting(memberId, clubId, dto));
     }
 
-    @GetMapping("/api/clubs/{club-id}/meetings")
+    @GetMapping
     public ResponseEntity<List<MeetingResponseDto>> findMeetingsByClubId(
             @PathVariable("club-id") @Positive Long clubId
     ) {
@@ -41,7 +42,7 @@ public class MeetingController {
                 .body(meetingService.findMeetingsByClubId(memberId, clubId));
     }
 
-    @PatchMapping("/api/clubs/{club-id}/meetings/{meeting-id}")
+    @PatchMapping("/{meeting-id}")
     public ResponseEntity<MeetingResponseDto> updateMeeting(
             @PathVariable("meeting-id") @Positive Long meetingId,
             @RequestBody MeetingUpdateRequestDto dto
@@ -51,7 +52,7 @@ public class MeetingController {
                 .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
 
-    @DeleteMapping("/api/clubs/{club-id}/meetings/{meeting-id}")
+    @DeleteMapping("/{meeting-id}")
     public ResponseEntity<Void> deleteMeeting(
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -8,10 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Validated
 @RestController
@@ -29,5 +28,15 @@ public class MeetingController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(meetingService.createMeeting(memberId, clubId, dto));
+    }
+
+    @GetMapping("/api/clubs/{club-id}/meetings")
+    public ResponseEntity<List<MeetingResponseDto>> findMeetingsByClubId(
+            @PathVariable("club-id") @Positive Long clubId
+    ) {
+        Long memberId = 1L;
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(meetingService.findMeetingsByClubId(memberId, clubId));
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -1,11 +1,33 @@
 package com.mobble.mobbleserver.domain.meeting.controller;
 
+import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
+import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
+import com.mobble.mobbleserver.domain.meeting.service.MeetingService;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/meeting")
 public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @PostMapping("/api/clubs/{club-id}/meetings")
+    public ResponseEntity<MeetingResponseDto> createMeeting(
+            @PathVariable("club-id") @Positive Long clubId,
+            @RequestBody MeetingRequestDto dto
+    ) {
+        Long memberId = 1L;
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(meetingService.createMeeting(memberId, clubId, dto));
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -41,16 +41,6 @@ public class MeetingController {
                 .body(meetingService.findMeetingsByClubId(memberId, clubId));
     }
 
-    @GetMapping("/api/meetings/{meeting-id}")
-    public ResponseEntity<MeetingResponseDto> findMeeting(
-            @PathVariable("meeting-id") @Positive Long meetingId
-    ) {
-        Long memberId = 1L;
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(meetingService.findMeetingById(meetingId, memberId));
-    }
-
     @PatchMapping("/api/clubs/{club-id}/meetings/{meeting-id}")
     public ResponseEntity<MeetingResponseDto> updateMeeting(
             @PathVariable("meeting-id") @Positive Long meetingId,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -39,4 +39,14 @@ public class MeetingController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.findMeetingsByClubId(memberId, clubId));
     }
+
+    @GetMapping("/api/meetings/{meeting-id}")
+    public ResponseEntity<MeetingResponseDto> findMeeting(
+            @PathVariable("meeting-id") @Positive Long meetingId
+    ) {
+        Long memberId = 1L;
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(meetingService.findMeetingById(meetingId, memberId));
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package com.mobble.mobbleserver.domain.meeting.controller;
 
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
+import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingUpdateRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
 import com.mobble.mobbleserver.domain.meeting.service.MeetingService;
 import jakarta.validation.constraints.Positive;
@@ -48,5 +49,15 @@ public class MeetingController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.findMeetingById(meetingId, memberId));
+    }
+
+    @PatchMapping("/api/meetings/{meeting-id}")
+    public ResponseEntity<MeetingResponseDto> updateMeeting(
+            @PathVariable("meeting-id") @Positive Long meetingId,
+            @RequestBody MeetingUpdateRequestDto dto
+    ) {
+        Long memberId = 1L;
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -1,0 +1,11 @@
+package com.mobble.mobbleserver.domain.meeting.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meeting")
+public class MeetingController {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
@@ -1,4 +1,30 @@
 package com.mobble.mobbleserver.domain.meeting.dto.request;
 
-public record MeetingRequestDto() {
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.meeting.entity.MeetingType;
+
+import java.time.LocalDateTime;
+
+public record MeetingRequestDto(
+        String title,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        LocalDateTime dateTime,
+        String location,
+        String cost,
+        Integer memberLimit,
+        MeetingType type
+) {
+    public Meeting toEntity(ClubMember host) {
+        return Meeting.createMeeting(
+                host,
+                this.title,
+                this.dateTime,
+                this.location,
+                this.cost,
+                this.memberLimit,
+                this.type
+        );
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
@@ -17,6 +17,7 @@ public record MeetingRequestDto(
         Integer memberLimit,
         MeetingType type
 ) {
+
     public Meeting toEntity(ClubMember hostMember) {
         return Meeting.createMeeting(
                 hostMember,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 
 public record MeetingRequestDto(
         String title,
+
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime dateTime,
         String location,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
@@ -1,0 +1,4 @@
+package com.mobble.mobbleserver.domain.meeting.dto.request;
+
+public record MeetingRequestDto() {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingRequestDto.java
@@ -16,9 +16,9 @@ public record MeetingRequestDto(
         Integer memberLimit,
         MeetingType type
 ) {
-    public Meeting toEntity(ClubMember host) {
+    public Meeting toEntity(ClubMember hostMember) {
         return Meeting.createMeeting(
-                host,
+                hostMember,
                 this.title,
                 this.dateTime,
                 this.location,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingUpdateRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.mobble.mobbleserver.domain.meeting.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mobble.mobbleserver.domain.meeting.entity.MeetingType;
+
+import java.time.LocalDateTime;
+
+public record MeetingUpdateRequestDto(
+        String title,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        LocalDateTime dateTime,
+        String location,
+        String cost,
+        Integer memberLimit,
+        MeetingType type
+) {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingUpdateRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/request/MeetingUpdateRequestDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 public record MeetingUpdateRequestDto(
         String title,
+
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime dateTime,
         String location,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -16,6 +16,7 @@ public record MeetingResponseDto(
         MeetingType type
 //        String dDay //Todo d-day 추가
 ) {
+    
     public static MeetingResponseDto toDto(Meeting meeting) {
         return new MeetingResponseDto(
                 meeting.getId(),

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -1,0 +1,4 @@
+package com.mobble.mobbleserver.domain.meeting.dto.response;
+
+public record MeetingResponseDto() {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -1,4 +1,32 @@
 package com.mobble.mobbleserver.domain.meeting.dto.response;
 
-public record MeetingResponseDto() {
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.meeting.entity.MeetingType;
+
+import java.time.LocalDateTime;
+
+public record MeetingResponseDto(
+        Long meetingId,
+        Long clubId,
+        String title,
+        LocalDateTime dateTime,
+        String location,
+        String cost,
+        Integer memberLimit,
+        MeetingType type
+//        String dDay //Todo d-day 추가
+) {
+    public static MeetingResponseDto toDto(Meeting meeting) {
+        return new MeetingResponseDto(
+                meeting.getId(),
+                meeting.getClubMember().getClub().getId(),
+                meeting.getTitle(),
+                meeting.getDatetime(),
+                meeting.getLocation(),
+                meeting.getCost(),
+                meeting.getMemberLimit(),
+                meeting.getType()
+//                dDay
+        );
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.meeting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.entity.MeetingType;
 
@@ -9,6 +10,8 @@ public record MeetingResponseDto(
         Long meetingId,
         Long clubId,
         String title,
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime dateTime,
         String location,
         String cost,

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/entity/Meeting.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.meeting.entity;
 
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,9 +19,9 @@ public class Meeting {
     @Column(name = "meeting_id")
     private Long id;
 
-//    @ManyToOne
-//    @JoinColumn(name = "club_member_id")
-//    private ClubMember clubMemberId;
+    @ManyToOne
+    @JoinColumn(name = "club_member_id")
+    private ClubMember clubMember;
 
     private String title;
 
@@ -36,10 +37,9 @@ public class Meeting {
     @Enumerated(EnumType.STRING)
     private MeetingType type;
 
-    //TODO ClubMember 필요
     @Builder
     private Meeting(
-            /*ClubMember clubMember, */
+            ClubMember clubMember,
             String title,
             LocalDateTime datetime,
             String location,
@@ -47,7 +47,7 @@ public class Meeting {
             int memberLimit,
             MeetingType type
     ) {
-        //this.clubMember = clubMember
+        this.clubMember = clubMember;
         this.title = title;
         this.datetime = datetime;
         this.location = location;
@@ -56,9 +56,8 @@ public class Meeting {
         this.type = type;
     }
 
-    //TODO ClubMember 필요
     public static Meeting createMeeting(
-//            ClubMember clubMember,
+            ClubMember clubMember,
             String title,
             LocalDateTime datetime,
             String location,
@@ -67,6 +66,7 @@ public class Meeting {
             MeetingType type
     ) {
         return Meeting.builder()
+                .clubMember(clubMember)
                 .title(title)
                 .datetime(datetime)
                 .location(location)

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/entity/Meeting.java
@@ -75,4 +75,21 @@ public class Meeting {
                 .type(type)
                 .build();
     }
+
+    public void updateMeeting(
+            String title,
+            LocalDateTime dateTime,
+            String location,
+            String cost,
+            Integer memberLimit,
+            MeetingType type
+    ) {
+        //Todo null 검증 로직 추가
+        this.title = title;
+        this.datetime = dateTime;
+        this.location = location;
+        this.cost = cost;
+        this.memberLimit = memberLimit;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/repository/MeetingRepository.java
@@ -3,5 +3,9 @@ package com.mobble.mobbleserver.domain.meeting.repository;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    //    List<Meeting> findMeetingsByClubId(Long clubId);
+    List<Meeting> findByClubMember_Club_Id(Long clubId);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -1,5 +1,13 @@
 package com.mobble.mobbleserver.domain.meeting.service;
 
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
+import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
+import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
+import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +16,24 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+    private final MemberValidator memberValidator;
+    private final ClubMemberValidator clubMemberValidator;
+
+    @Transactional
+    public MeetingResponseDto createMeeting(Long memberId, Long clubId, MeetingRequestDto dto) {
+        ClubMember host = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+
+        ClubMemberRole clubMemberRole = host.getClubMemberRole();
+
+        if (clubMemberRole == ClubMemberRole.MEMBER) {
+            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용
+        }
+
+        Meeting meeting = dto.toEntity(host);
+        //Todo d-day 표시 추가
+
+        return MeetingResponseDto.toDto(meetingRepository.save(meeting));
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -80,6 +80,7 @@ public class MeetingService {
         return MeetingResponseDto.toDto(meetingRepository.save(meeting));
     }
 
+    @Transactional
     public void deleteMeeting(Long memberId, Long meetingId) {
         Meeting meeting = findMeetingByMeetingId(meetingId);
 

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,5 +37,14 @@ public class MeetingService {
         //Todo d-day 표시 추가
 
         return MeetingResponseDto.toDto(meetingRepository.save(meeting));
+    }
+
+    public List<MeetingResponseDto> findMeetingsByClubId(Long memberId, Long clubId) {
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        List<Meeting> meetings = meetingRepository.findByClubMember_Club_Id(clubId);
+
+        return meetings.stream()
+                .map(meeting -> MeetingResponseDto.toDto(meeting))
+                .toList();
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -40,7 +40,7 @@ public class MeetingService {
     }
 
     public List<MeetingResponseDto> findMeetingsByClubId(Long memberId, Long clubId) {
-        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
         List<Meeting> meetings = meetingRepository.findByClubMember_Club_Id(clubId);
 
         return meetings.stream()

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -8,7 +8,6 @@ import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingUpdateRequestDt
 import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
-import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +20,6 @@ import java.util.List;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
-    private final MemberValidator memberValidator;
     private final ClubMemberValidator clubMemberValidator;
 
     @Transactional

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -82,6 +82,20 @@ public class MeetingService {
         return MeetingResponseDto.toDto(meetingRepository.save(meeting));
     }
 
+    public void deleteMeeting(Long memberId, Long meetingId) {
+        Meeting meeting = findMeetingByMeetingId(meetingId);
+
+        Long clubId = meeting.getClubMember().getClub().getId();
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        ClubMemberRole clubMemberRole = clubMember.getClubMemberRole();
+
+        if (clubMemberRole == ClubMemberRole.MEMBER) {
+            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
+        }
+
+        meetingRepository.delete(meeting);
+    }
+
     private Meeting findMeetingByMeetingId(Long meetingId) {
         return meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException(""));

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -49,9 +49,7 @@ public class MeetingService {
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
         ClubMemberRole clubMemberRole = clubMember.getClubMemberRole();
 
-        if (clubMemberRole == ClubMemberRole.MEMBER) {
-            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
-        }
+        if (clubMemberRole == ClubMemberRole.MEMBER) throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용
 
         meeting.updateMeeting(
                 dto.title(),
@@ -73,9 +71,7 @@ public class MeetingService {
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
         ClubMemberRole clubMemberRole = clubMember.getClubMemberRole();
 
-        if (clubMemberRole == ClubMemberRole.MEMBER) {
-            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
-        }
+        if (clubMemberRole == ClubMemberRole.MEMBER) throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용
 
         meetingRepository.delete(meeting);
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -26,12 +26,6 @@ public class MeetingService {
     public MeetingResponseDto createMeeting(Long memberId, Long clubId, MeetingRequestDto dto) {
         ClubMember hostMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
 
-        ClubMemberRole clubMemberRole = hostMember.getClubMemberRole();
-
-        if (clubMemberRole == ClubMemberRole.MEMBER) {
-            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
-        }
-
         Meeting meeting = dto.toEntity(hostMember);
         //Todo d-day 표시 추가
 

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -23,15 +23,15 @@ public class MeetingService {
 
     @Transactional
     public MeetingResponseDto createMeeting(Long memberId, Long clubId, MeetingRequestDto dto) {
-        ClubMember host = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        ClubMember hostMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
 
-        ClubMemberRole clubMemberRole = host.getClubMemberRole();
+        ClubMemberRole clubMemberRole = hostMember.getClubMemberRole();
 
         if (clubMemberRole == ClubMemberRole.MEMBER) {
             throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용
         }
 
-        Meeting meeting = dto.toEntity(host);
+        Meeting meeting = dto.toEntity(hostMember);
         //Todo d-day 표시 추가
 
         return MeetingResponseDto.toDto(meetingRepository.save(meeting));

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -4,6 +4,7 @@ import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
 import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
+import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingUpdateRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
@@ -30,7 +31,7 @@ public class MeetingService {
         ClubMemberRole clubMemberRole = hostMember.getClubMemberRole();
 
         if (clubMemberRole == ClubMemberRole.MEMBER) {
-            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용
+            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
         }
 
         Meeting meeting = dto.toEntity(hostMember);
@@ -55,6 +56,30 @@ public class MeetingService {
         clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
 
         return MeetingResponseDto.toDto(meeting);
+    }
+
+    @Transactional
+    public MeetingResponseDto updateMeeting(Long memberId, Long meetingId, MeetingUpdateRequestDto dto) {
+        Meeting meeting = findMeetingByMeetingId(meetingId);
+
+        Long clubId = meeting.getClubMember().getClub().getId();
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        ClubMemberRole clubMemberRole = clubMember.getClubMemberRole();
+
+        if (clubMemberRole == ClubMemberRole.MEMBER) {
+            throw new IllegalArgumentException(""); //Todo 커스텀 예외 적용?
+        }
+
+        meeting.updateMeeting(
+                dto.title(),
+                dto.dateTime(),
+                dto.location(),
+                dto.cost(),
+                dto.memberLimit(),
+                dto.type()
+        );
+
+        return MeetingResponseDto.toDto(meetingRepository.save(meeting));
     }
 
     private Meeting findMeetingByMeetingId(Long meetingId) {

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -47,4 +47,18 @@ public class MeetingService {
                 .map(meeting -> MeetingResponseDto.toDto(meeting))
                 .toList();
     }
+
+    public MeetingResponseDto findMeetingById(Long meetingId, Long memberId) {
+        Meeting meeting = findMeetingByMeetingId(meetingId); //Todo 커스텀 예외 적용
+
+        Long clubId = meeting.getClubMember().getClub().getId();
+        clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+
+        return MeetingResponseDto.toDto(meeting);
+    }
+
+    private Meeting findMeetingByMeetingId(Long meetingId) {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException(""));
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -1,0 +1,11 @@
+package com.mobble.mobbleserver.domain.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingService {
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -41,15 +41,6 @@ public class MeetingService {
                 .toList();
     }
 
-    public MeetingResponseDto findMeetingById(Long meetingId, Long memberId) {
-        Meeting meeting = findMeetingByMeetingId(meetingId); //Todo 커스텀 예외 적용
-
-        Long clubId = meeting.getClubMember().getClub().getId();
-        clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
-
-        return MeetingResponseDto.toDto(meeting);
-    }
-
     @Transactional
     public MeetingResponseDto updateMeeting(Long memberId, Long meetingId, MeetingUpdateRequestDto dto) {
         Meeting meeting = findMeetingByMeetingId(meetingId);


### PR DESCRIPTION
## 📄 feat: 미팅 기능 CRUD 구현

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #101 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- 미팅 CRUD 구현
- 조회는 목록, 단 건 조회 구현

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
- 기본적인 CRUD기능만 구현해둠 기획 당시 구현할 기능(참석 멤버 노출, D-day 노출, 인원 제한, 이미지 노출 등)은 리팩토링 시 추가 예정
- 모임장&관리자만 수정, 삭제 가능하도록 구현

## 📝 기타 사항
- 수정, 삭제만 클럽 권한 검증중이나, 무분별한 생성 가능성 고려하여 생성 시에도 권한 검증 고려
