### PR TITLE
Test/article validator

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
@@ -40,3 +40,16 @@ class ArticleValidatorTest {
         // then
         assertThat(article).isEqualTo(mockArticle);
     }
+
+    @Test
+    @DisplayName("게시글 ID로 조회 실패 시 예외 발생")
+    void fails_when_find_article_or_throw() {
+        // given
+        Long articleId = 1L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> articleValidator.findArticleByArticleIdOrThrow(articleId))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ArticleErrorCode.NOT_FOUND.message());
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
@@ -72,3 +72,20 @@ class ArticleValidatorTest {
         // then
         assertThat(article).isEqualTo(mockArticle);
     }
+
+    @Test
+    @DisplayName("게시글 ID와 작성자 ID로 조회 실패 시 예외 발생")
+    void fails_when_find_article_by_article_id_and_member_id_or_throw() {
+        // given
+        Long articleId = 10L;
+        Long memberId = 20L;
+
+        given(articleRepository.findArticleByIdAndMemberId(articleId, memberId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> articleValidator.findArticleByArticleIdAndMemberIdOrThrow(articleId, memberId))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ArticleErrorCode.NOT_FOUND_TO_MEMBER.message());
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
@@ -26,6 +26,7 @@ class ArticleValidatorTest {
 
     @InjectMocks
     private ArticleValidator articleValidator;
+
     @Test
     @DisplayName("게시글 ID로 조회 성공")
     void success_when_find_article_or_throw() {
@@ -52,4 +53,22 @@ class ArticleValidatorTest {
         assertThatThrownBy(() -> articleValidator.findArticleByArticleIdOrThrow(articleId))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(ArticleErrorCode.NOT_FOUND.message());
+    }
+
+    @Test
+    @DisplayName("게시글 ID와 작성자 ID로 조회 성공")
+    void success_when_find_article_by_article_id_and_member_id_or_throw() {
+        // given
+        Long articleId = 10L;
+        Long memberId = 20L;
+        Article mockArticle = mock(Article.class);
+
+        given(articleRepository.findArticleByIdAndMemberId(articleId, memberId))
+                .willReturn(Optional.of(mockArticle));
+
+        // when
+        Article article = articleValidator.findArticleByArticleIdAndMemberIdOrThrow(articleId, memberId);
+
+        // then
+        assertThat(article).isEqualTo(mockArticle);
     }

--- a/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
@@ -26,3 +26,17 @@ class ArticleValidatorTest {
 
     @InjectMocks
     private ArticleValidator articleValidator;
+    @Test
+    @DisplayName("게시글 ID로 조회 성공")
+    void success_when_find_article_or_throw() {
+        // given
+        Long articleId = 1L;
+        Article mockArticle = mock(Article.class);
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(mockArticle));
+
+        // when
+        Article article = articleValidator.findArticleByArticleIdOrThrow(articleId);
+
+        // then
+        assertThat(article).isEqualTo(mockArticle);
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/validator/ArticleValidatorTest.java
@@ -1,0 +1,28 @@
+package com.mobble.mobbleserver.domain.article.validator;
+
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.article.repository.ArticleRepository;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.article.ArticleErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleValidatorTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private ArticleValidator articleValidator;


### PR DESCRIPTION
## 📄 Test: ArticleValidator 단위 테스트 추가


#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #106 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ArticleValidatorTest 클래스 작성
- 게시글 ID로 조회 성공/실패 테스트 구현
- 게시글 ID + 작성자 ID로 조회 성공/실패 테스트 구현
- DomainException 및 ArticleErrorCode 예외 메시지 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

