### PR TITLE
Refactor/login member

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.like.baseLike.controller;
 
+import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
 import com.mobble.mobbleserver.domain.like.baseLike.service.LikeDispatcherService;
@@ -26,7 +27,7 @@ public class LikeController {
     }
 
     @GetMapping("/members")
-    public ResponseEntity<?> getMemberList(
+    public ResponseEntity<LikeMemberListResponseDto> getMemberList(
             @RequestParam LikeType likeType,
             @RequestParam Long targetId
     ) {

--- a/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
@@ -1,6 +1,5 @@
 package com.mobble.mobbleserver.domain.like.baseLike.controller;
 
-import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
@@ -20,12 +19,10 @@ public class LikeController {
 
     @PostMapping
     public ResponseEntity<LikeToggleResponseDto> toggleLike(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @RequestParam LikeType likeType,
             @RequestParam Long targetId
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(likeDispatcherService.toggleLike(likeType, targetId, memberId));
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/like/baseLike/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.like.baseLike.controller;
 
+import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
@@ -7,6 +8,7 @@ import com.mobble.mobbleserver.domain.like.baseLike.service.LikeDispatcherServic
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,10 +20,12 @@ public class LikeController {
 
     @PostMapping
     public ResponseEntity<LikeToggleResponseDto> toggleLike(
+            @AuthenticationPrincipal AuthMember authMember,
             @RequestParam LikeType likeType,
             @RequestParam Long targetId
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(likeDispatcherService.toggleLike(likeType, targetId, memberId));
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.meeting.controller;
 
+import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingUpdateRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,10 +25,11 @@ public class MeetingController {
 
     @PostMapping
     public ResponseEntity<MeetingResponseDto> createMeeting(
+            @AuthenticationPrincipal AuthMember authMember,
             @PathVariable("club-id") @Positive Long clubId,
             @RequestBody MeetingRequestDto dto
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(meetingService.createMeeting(memberId, clubId, dto));
@@ -34,9 +37,10 @@ public class MeetingController {
 
     @GetMapping
     public ResponseEntity<List<MeetingResponseDto>> findMeetingsByClubId(
+            @AuthenticationPrincipal AuthMember authMember,
             @PathVariable("club-id") @Positive Long clubId
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.findMeetingsByClubId(memberId, clubId));
@@ -44,19 +48,23 @@ public class MeetingController {
 
     @PatchMapping("/{meeting-id}")
     public ResponseEntity<MeetingResponseDto> updateMeeting(
+            @AuthenticationPrincipal AuthMember authMember,
             @PathVariable("meeting-id") @Positive Long meetingId,
             @RequestBody MeetingUpdateRequestDto dto
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
 
     @DeleteMapping("/{meeting-id}")
     public ResponseEntity<Void> deleteMeeting(
+            @AuthenticationPrincipal AuthMember authMember,
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
+
         meetingService.deleteMeeting(memberId, meetingId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -1,6 +1,5 @@
 package com.mobble.mobbleserver.domain.meeting.controller;
 
-import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.request.MeetingUpdateRequestDto;
 import com.mobble.mobbleserver.domain.meeting.dto.response.MeetingResponseDto;
@@ -25,23 +24,19 @@ public class MeetingController {
 
     @PostMapping
     public ResponseEntity<MeetingResponseDto> createMeeting(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @PathVariable("club-id") @Positive Long clubId,
             @RequestBody MeetingRequestDto dto
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(meetingService.createMeeting(memberId, clubId, dto));
     }
 
     @GetMapping
     public ResponseEntity<List<MeetingResponseDto>> findMeetingsByClubId(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @PathVariable("club-id") @Positive Long clubId
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.findMeetingsByClubId(memberId, clubId));
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/controller/MeetingController.java
@@ -48,23 +48,19 @@ public class MeetingController {
 
     @PatchMapping("/{meeting-id}")
     public ResponseEntity<MeetingResponseDto> updateMeeting(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @PathVariable("meeting-id") @Positive Long meetingId,
             @RequestBody MeetingUpdateRequestDto dto
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingService.updateMeeting(memberId, meetingId, dto));
     }
 
     @DeleteMapping("/{meeting-id}")
     public ResponseEntity<Void> deleteMeeting(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {
-        Long memberId = authMember.memberId();
-
         meetingService.deleteMeeting(memberId, meetingId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();

--- a/src/main/java/com/mobble/mobbleserver/domain/meetingMember/controller/MeetingMemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meetingMember/controller/MeetingMemberController.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.meetingMember.controller;
 
+import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingAttendanceResponseDto;
 import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingMemberListResponseDto;
 import com.mobble.mobbleserver.domain.meetingMember.service.MeetingMemberService;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,9 +22,11 @@ public class MeetingMemberController {
 
     @PostMapping
     public ResponseEntity<MeetingAttendanceResponseDto> toggleAttendanceMeeting(
+            @AuthenticationPrincipal AuthMember authMember,
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingMemberService.attendMeeting(meetingId, memberId));
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/meetingMember/controller/MeetingMemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meetingMember/controller/MeetingMemberController.java
@@ -1,6 +1,5 @@
 package com.mobble.mobbleserver.domain.meetingMember.controller;
 
-import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingAttendanceResponseDto;
 import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingMemberListResponseDto;
 import com.mobble.mobbleserver.domain.meetingMember.service.MeetingMemberService;
@@ -22,11 +21,9 @@ public class MeetingMemberController {
 
     @PostMapping
     public ResponseEntity<MeetingAttendanceResponseDto> toggleAttendanceMeeting(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @PathVariable("meeting-id") @Positive Long meetingId
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(meetingMemberService.attendMeeting(meetingId, memberId));
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
@@ -22,30 +22,25 @@ public class MemberController {
 
     @GetMapping
     public ResponseEntity<MemberResponseDto> getMember(
-            @AuthenticationPrincipal AuthMember authMember
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberService.getMember(memberId));
     }
 
     @PatchMapping
     public ResponseEntity<MemberResponseDto> updateMember(
-            @AuthenticationPrincipal AuthMember authMember,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
             @RequestBody @Valid MemberUpdateRequestDto dto
     ) {
-        Long memberId = authMember.memberId();
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberService.updateMember(memberId, dto));
     }
 
     @DeleteMapping
     public ResponseEntity<Void> deleteMember(
-            @AuthenticationPrincipal AuthMember authMember
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
     ) {
-        Long memberId = authMember.memberId();
         memberService.deleteMember(memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.member.controller;
 
+import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.member.dto.request.MemberUpdateRequestDto;
 import com.mobble.mobbleserver.domain.member.dto.response.MemberResponseDto;
 import com.mobble.mobbleserver.domain.member.service.MemberService;
@@ -7,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,8 +21,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<MemberResponseDto> getMember() {
-        Long memberId = 1L;
+    public ResponseEntity<MemberResponseDto> getMember(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        Long memberId = authMember.memberId();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberService.getMember(memberId));
@@ -28,17 +32,20 @@ public class MemberController {
 
     @PatchMapping
     public ResponseEntity<MemberResponseDto> updateMember(
+            @AuthenticationPrincipal AuthMember authMember,
             @RequestBody @Valid MemberUpdateRequestDto dto
     ) {
-        Long memberId = 1L;
+        Long memberId = authMember.memberId();
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(memberService.updateMember(memberId, dto));
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteMember() {
-        Long memberId = 1L;
+    public ResponseEntity<Void> deleteMember(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+        Long memberId = authMember.memberId();
         memberService.deleteMember(memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.mobble.mobbleserver.domain.member.controller;
 
-import com.mobble.mobbleserver.account.auth.principal.AuthMember;
 import com.mobble.mobbleserver.domain.member.dto.request.MemberUpdateRequestDto;
 import com.mobble.mobbleserver.domain.member.dto.response.MemberResponseDto;
 import com.mobble.mobbleserver.domain.member.service.MemberService;
@@ -39,7 +38,7 @@ public class MemberController {
 
     @DeleteMapping
     public ResponseEntity<Void> deleteMember(
-            @AuthenticationPrincipal(expression = "memberId") Long memberId,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
         memberService.deleteMember(memberId);
 

--- a/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
@@ -3,7 +3,6 @@ package com.mobble.mobbleserver.domain.member.service;
 import com.mobble.mobbleserver.domain.member.dto.request.MemberUpdateRequestDto;
 import com.mobble.mobbleserver.domain.member.dto.response.MemberResponseDto;
 import com.mobble.mobbleserver.domain.member.entity.Member;
-import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
 
-    private final MemberRepository memberRepository;
     private final MemberValidator memberValidator;
 
     public MemberResponseDto getMember(Long memberId) {


### PR DESCRIPTION
## 📄 임시 memberId 제거 및 @AuthenticationPrincipal 기반 인증 정보 주입
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #108 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- 임시 memberId 제거, @AuthenticationPrincipal 적용 
- JWT 필터에서 설정한 AuthMember를 기반으로 인증 정보를 주입받도록 통일

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- 아래와 같이 @AuthenticationPrincipal(expression = "memberId")를 사용해 인증된 사용자 정보를 간편하게 주입받아 사용
```Java
public ResponseEntity<MemberResponseDto> getMember(
            @AuthenticationPrincipal(expression = "memberId") Long memberId
    ) {
        return ResponseEntity.status(HttpStatus.OK)
                .body(memberService.getMember(memberId));
    }
```