### PR TITLE
Test/article repository

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.mobble.mobbleserver.domain.article.entity.Article;
 import com.mobble.mobbleserver.domain.article.entity.ArticleType;
 import com.mobble.mobbleserver.domain.article.repository.dto.ArticleLikeInfoDto;
 import com.mobble.mobbleserver.domain.article.repository.dto.ArticleLikeProjection;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
@@ -71,3 +71,65 @@ class ArticleRepositoryImplTest {
         assertThat(onlyNotice).hasSize(1);
         assertThat(onlyNotice.get(0).getArticleType()).isEqualTo(ArticleType.NOTICE);
     }
+
+    @Test
+    @DisplayName("게시글 ID들로 좋아요 수 & 사용자의 좋아요 여부 조회 성공")
+    void success_when_find_like_info_by_article_ids_and_member_id() {
+        // given
+        Member me = MemberTestFixture.createDefaultMember();
+        Member other = MemberTestFixture.createDefaultMember();
+
+        ClubCategory category = ClubCategory.createClubCategory("SOCCER");
+        Club club = ClubTestFixture.createDefaultClub(category);
+
+        em.persist(category);
+        em.persist(me);
+        em.persist(other);
+        em.persist(club);
+
+        Article a1 = ArticleTestFixture.createWithMemberAndClub(me, club);
+        a1.updateArticle(ArticleType.FREE, "a1", "c1");
+        Article a2 = ArticleTestFixture.createWithMemberAndClub(me, club);
+        a2.updateArticle(ArticleType.FREE, "a2", "c2");
+
+        em.persist(a1);
+        em.persist(a2);
+
+        ArticleLike l1 = ArticleLike.createArticleLike(a1, me);
+        ArticleLike l2 = ArticleLike.createArticleLike(a1, other);
+        ArticleLike l3 = ArticleLike.createArticleLike(a2, other);
+
+        em.persist(l1);
+        em.persist(l2);
+        em.persist(l3);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Long> ids = List.of(a1.getId(), a2.getId());
+        Map<Long, ArticleLikeInfoDto> infoForMe =
+                articleRepository.findLikeInfoByArticleIdsAndMemberId(ids, me.getId());
+        Map<Long, ArticleLikeInfoDto> infoForNullUser =
+                articleRepository.findLikeInfoByArticleIdsAndMemberId(ids, null);
+
+        // then
+        assertThat(infoForMe).hasSize(2);
+        assertThat(infoForNullUser).hasSize(2);
+
+        ArticleLikeInfoDto a1InfoForMe = infoForMe.get(a1.getId());
+        assertThat(a1InfoForMe.likeCount()).isEqualTo(2);
+        assertThat(a1InfoForMe.isLiked()).isTrue();
+
+        ArticleLikeInfoDto a2InfoForMe = infoForMe.get(a2.getId());
+        assertThat(a2InfoForMe.likeCount()).isEqualTo(1);
+        assertThat(a2InfoForMe.isLiked()).isFalse();
+
+        ArticleLikeInfoDto a1InfoNull = infoForNullUser.get(a1.getId());
+        assertThat(a1InfoNull.likeCount()).isEqualTo(2);
+        assertThat(a1InfoNull.isLiked()).isFalse();
+
+        ArticleLikeInfoDto a2InfoNull = infoForNullUser.get(a2.getId());
+        assertThat(a2InfoNull.likeCount()).isEqualTo(1);
+        assertThat(a2InfoNull.isLiked()).isFalse();
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
@@ -133,3 +133,33 @@ class ArticleRepositoryImplTest {
         assertThat(a2InfoNull.likeCount()).isEqualTo(1);
         assertThat(a2InfoNull.isLiked()).isFalse();
     }
+
+    @Test
+    @DisplayName("클럽 ID로 게시글 ID 목록 조회 성공")
+    void success_when_find_article_ids_by_club_id() {
+        // given
+        Member writer = MemberTestFixture.createDefaultMember();
+        ClubCategory category = ClubCategory.createClubCategory("SOCCER");
+        Club club = ClubTestFixture.createDefaultClub(category);
+
+        em.persist(category);
+        em.persist(writer);
+        em.persist(club);
+
+        Article a1 = ArticleTestFixture.createWithMemberAndClub(writer, club);
+        a1.updateArticle(ArticleType.FREE, "a1", "c1");
+        Article a2 = ArticleTestFixture.createWithMemberAndClub(writer, club);
+        a2.updateArticle(ArticleType.NOTICE, "a2", "c2");
+
+        em.persist(a1);
+        em.persist(a2);
+        em.flush();
+        em.clear();
+
+        // when
+        List<Long> ids = articleRepository.findArticleIdsByClubId(club.getId());
+
+        // then
+        assertThat(ids).containsExactlyInAnyOrder(a1.getId(), a2.getId());
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
@@ -1,0 +1,34 @@
+package com.mobble.mobbleserver.domain.article.repository;
+
+import com.mobble.mobbleserver.config.QueryDslConfig;
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.article.entity.ArticleType;
+import com.mobble.mobbleserver.domain.article.repository.dto.ArticleLikeInfoDto;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.support.fixture.article.ArticleTestFixture;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class ArticleRepositoryImplTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private EntityManager em;

--- a/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/article/repository/ArticleRepositoryImplTest.java
@@ -32,3 +32,42 @@ class ArticleRepositoryImplTest {
 
     @Autowired
     private EntityManager em;
+
+    @Test
+    @DisplayName("클럽 ID(+옵션: 타입)로 게시글 목록 조회 성공")
+    void success_when_find_articles_by_club_id_with_optional_type() {
+        // given
+        Member writer = MemberTestFixture.createDefaultMember();
+        ClubCategory category = ClubCategory.createClubCategory("SOCCER");
+        Club club = ClubTestFixture.createDefaultClub(category);
+
+        em.persist(category);
+        em.persist(writer);
+        em.persist(club);
+
+        Article a1 = ArticleTestFixture.createWithMemberAndClub(writer, club);
+        a1.updateArticle(ArticleType.FREE, "t1", "c1");
+        Article a2 = ArticleTestFixture.createWithMemberAndClub(writer, club);
+        a2.updateArticle(ArticleType.NOTICE, "t2", "c2");
+
+        em.persist(a1);
+        em.persist(a2);
+        em.flush();
+        em.clear();
+
+        // when
+        List<Article> allByClub = articleRepository.findArticlesByClubId(club.getId(), null); // 타입 필터 없음
+        List<Article> onlyFree = articleRepository.findArticlesByClubId(club.getId(), ArticleType.FREE);
+        List<Article> onlyNotice = articleRepository.findArticlesByClubId(club.getId(), ArticleType.NOTICE);
+
+        // then
+        assertThat(allByClub).hasSize(2);
+        assertThat(allByClub).extracting(Article::getArticleType)
+                .containsExactlyInAnyOrder(ArticleType.FREE, ArticleType.NOTICE);
+
+        assertThat(onlyFree).hasSize(1);
+        assertThat(onlyFree.get(0).getArticleType()).isEqualTo(ArticleType.FREE);
+
+        assertThat(onlyNotice).hasSize(1);
+        assertThat(onlyNotice.get(0).getArticleType()).isEqualTo(ArticleType.NOTICE);
+    }


### PR DESCRIPTION
## 📄 ArticleRepositoryImpl 단위 테스트 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #105 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ArticleRepositoryImplTest 클래스 작성
- 클럽 ID(+옵션: 타입)으로 게시글 목록 조회 테스트
- 게시글 ID들로 좋아요 수 & 특정 사용자 좋아요 여부 조회 테스트
- 클럽 ID로 게시글 ID 목록 조회 테스트


## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

