### PR TITLE
Bug/clubchatroom delete error

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/entity/ClubChatRoom.java
@@ -38,4 +38,17 @@ public class ClubChatRoom {
                 .chatRoom(chatRoom)
                 .build();
     }
+
+    public void attachTo(Club club) {
+        if (this.club != club) throw new IllegalArgumentException("");
+
+        club.setClubChatRoomInternal(this);
+    }
+
+    public void detach() {
+        if (this.club == null) return;
+
+        this.club.setClubChatRoomInternal(null);
+        this.club = null;
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/repository/ClubChatRoomRepository.java
@@ -3,7 +3,11 @@ package com.mobble.mobbleserver.domain.chat.clubChatRoom.repository;
 import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClubChatRoomRepository extends JpaRepository<ClubChatRoom, Long> {
 
     boolean existsClubChatRoomByClubId(Long clubId);
+
+    Optional<ClubChatRoom> findByClubId(Long clubId);
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/service/ClubChatRoomService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/service/ClubChatRoomService.java
@@ -41,14 +41,14 @@ public class ClubChatRoomService {
 
     private final ChatMessageService chatMessageService;
 
-    private final MemberValidator memberValidator;
-    private final ClubMemberValidator clubMemberValidator;
-    private final ClubChatRoomValidator clubChatRoomValidator;
-
     private final ChatRoomParticipantRepository chatRoomParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ClubChatRoomRepository clubChatRoomRepository;
+
+    private final MemberValidator memberValidator;
+    private final ClubMemberValidator clubMemberValidator;
+    private final ClubChatRoomValidator clubChatRoomValidator;
 
     @Transactional
     public void sendGroupMessage(ClubChatMessageRequestDto dto, Long memberId) {
@@ -67,16 +67,23 @@ public class ClubChatRoomService {
     }
 
     @Transactional
-    public ClubChatRoomPreviewResponseDto createClubChatRoom(Club club, Member member) {
+    public ClubChatRoomPreviewResponseDto createClubChatRoom(Long clubId, Long memberId) {
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        Club club = clubMember.getClub();
+        Member member = clubMember.getMember();
+
         clubChatRoomValidator.existsClubChatRoomByClubIdOrThrow(club.getId());
 
         ChatRoom chatRoom = ChatRoom.createChatRoom(ChatRoomType.GROUP);
-        ChatRoomParticipant participant = ChatRoomParticipant.createChatRoomParticipant(chatRoom, member);
-        ClubChatRoom clubChatRoom = ClubChatRoom.createClubChatRoom(club, chatRoom);
-
         chatRoomRepository.save(chatRoom);
+
+        ChatRoomParticipant participant = ChatRoomParticipant.createChatRoomParticipant(chatRoom, member);
         chatRoomParticipantRepository.save(participant);
+
+        ClubChatRoom clubChatRoom = ClubChatRoom.createClubChatRoom(club, chatRoom);
         clubChatRoomRepository.save(clubChatRoom);
+
+        clubChatRoom.attachTo(club);
 
         return ClubChatRoomPreviewResponseDto.toDto(chatRoom, club, null, 0, null);
     }
@@ -136,10 +143,11 @@ public class ClubChatRoomService {
     }
 
     @Transactional
-    public void deleteClubChatRoom(Club club) {
-        ClubChatRoom clubChatRoom = club.getClubChatRoom();
-        if (clubChatRoom == null) return;
+    public void deleteClubChatRoom(Long clubId) {
+        ClubChatRoom clubChatRoom = clubChatRoomValidator.findClubChatRoomByClubIdOrThrow(clubId);
         ChatRoom chatRoom = clubChatRoom.getChatRoom();
+
+        clubChatRoom.detach();
 
         chatRoomParticipantRepository.deleteByChatRoomId(chatRoom.getId());
         chatMessageRepository.deleteByChatRoomId(chatRoom.getId());

--- a/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/validator/ClubChatRoomValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/chat/clubChatRoom/validator/ClubChatRoomValidator.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.chat.clubChatRoom.validator;
 
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
 import com.mobble.mobbleserver.domain.chat.clubChatRoom.repository.ClubChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,5 +13,10 @@ public class ClubChatRoomValidator {
 
     public void existsClubChatRoomByClubIdOrThrow(Long clubId) {
         if (clubChatRoomRepository.existsClubChatRoomByClubId(clubId)) throw new IllegalArgumentException("");
+    }
+
+    public ClubChatRoom findClubChatRoomByClubIdOrThrow(Long clubId) {
+        return clubChatRoomRepository.findByClubId(clubId)
+                .orElseThrow(() -> new IllegalArgumentException(""));
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/entity/Club.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/entity/Club.java
@@ -83,6 +83,10 @@ public class Club extends BaseEntity {
                 .build();
     }
 
+    public void setClubChatRoomInternal(ClubChatRoom chatRoom) {
+        this.clubChatRoom = chatRoom;
+    }
+
     public void updateClub(
             ClubCategory category,
             String name,

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -1,6 +1,8 @@
 package com.mobble.mobbleserver.domain.club.core.service;
 
 import com.mobble.mobbleserver.domain.article.repository.ArticleRepository;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.dto.response.ClubChatRoomPreviewResponseDto;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.service.ClubChatRoomService;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroup;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroupType;
 import com.mobble.mobbleserver.domain.club.ageGroup.repository.AgeGroupRepository;
@@ -37,6 +39,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ClubService {
 
+    private final ClubChatRoomService clubChatRoomService;
+
     private final ClubRepository clubRepository;
     private final ClubCategoryRepository clubCategoryRepository;
     private final ClubMemberRepository clubMemberRepository;
@@ -64,6 +68,9 @@ public class ClubService {
 
         List<AgeGroup> ageGroups = createClubAgeGroups(club, dto.ageGroup());
         ageGroupRepository.saveAll(ageGroups);
+
+        // Todo: 반환값이 Club 채팅방의 preview 에 필요한 데이터이기 때문에 반환 DTO에 포함 되어야 함
+        ClubChatRoomPreviewResponseDto clubChatRoom = clubChatRoomService.createClubChatRoom(club.getId(), member.getId());
 
         return buildClubResponse(club, member, member.getName());
     }
@@ -98,25 +105,27 @@ public class ClubService {
 
     @Transactional
     public void deleteClub(Long clubId, Long memberId) {
-        Club club = clubValidator.findClubByClubIdOrThrow(clubId);
-        Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
         ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
+        Club club = clubMember.getClub();
+
         assertLeader(clubMember);
 
-        clubLikeRepository.deleteClubLikeAllByClub_Id(clubId);
+        clubChatRoomService.deleteClubChatRoom(club.getId());
 
-        List<Long> articleIds = articleRepository.findArticleIdsByClubId(clubId);
+        clubLikeRepository.deleteClubLikeAllByClub_Id(club.getId());
+
+        List<Long> articleIds = articleRepository.findArticleIdsByClubId(club.getId());
 
         commentLikeRepository.deleteAllCommentLikeByComment_Article_IdIn(articleIds);
         commentRepository.deleteAllCommentByArticle_IdIn(articleIds);
         articleLikeRepository.deleteAllArticleLikeByArticle_IdIn(articleIds);
-        articleRepository.deleteAllArticleByClub_Id(clubId);
-        clubMemberRepository.deleteAllClubMemberByClubId(clubId);
+        articleRepository.deleteAllArticleByClub_Id(club.getId());
+        clubMemberRepository.deleteAllClubMemberByClubId(club.getId());
 
-        clubLikeRepository.deleteClubLikeAllByClub_Id(clubId);
-        ageGroupRepository.deleteAllClubAgeGroupByClubId(clubId);
+        clubLikeRepository.deleteClubLikeAllByClub_Id(club.getId());
+        ageGroupRepository.deleteAllClubAgeGroupByClubId(club.getId());
 
-        clubRepository.deleteById(clubId);
+        clubRepository.deleteById(club.getId());
     }
 
     private ClubCategory findCategoryOrThrow(String categoryName) {


### PR DESCRIPTION
## 📄 refactor: Club ↔ ClubChatRoom 연관관계 관리 안정화 (attachTo/detach) 및 생성·삭제 순서 정리

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #125

## ✅ 변경 사항
- ClubChatRoom ↔ Club 양방향 연관 관리 메서드 도입
    - ClubChatRoom.attachTo(Club) : 저장 이후 역방향(Club.clubChatRoom) 동기화
    - ClubChatRoom.detach() : 파라미터 없이 양쪽 참조 안전 해제(역방향 null → 소유측 null)
    - Club.setClubChatRoomInternal(ClubChatRoom) : 내부 동기화 전용 세터(null 허용)
- 생성·삭제 순서 정립으로 TransientObjectException 제거
    - 생성: ChatRoom → ChatRoomParticipant → ClubChatRoom(save) → clubChatRoom.attachTo(club)
    - 삭제: clubChatRoom.detach() 먼저 → participant/messages/ClubChatRoom/ChatRoom 순서 삭제
- 서비스 시그니처 정리
    - 컨트롤러에서 ID만 전달, 서비스 내부에서 영속 엔티티 재조회하여 동일 트랜잭션/영속성 컨텍스트 보장
- 도메인 가드 추가
    - attachTo에서 생성 시 주입된 Club과 다른 Club으로 바인딩 시도 시 예외(오사용 방지)

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->

## 📝 기타 사항
수정의 근본 목적은 영속성 컨텍스트의 객체 그래프 일관성 보장입니다. OneToOne의 스칼라 참조 특성상 “부모가 삭제될(또는 미저장) 자식을 참조”한 채로 flush가 일어나는 순간 TransientObjectException이 발생할 수 있으므로, 연관 해제(detach) → 삭제 순서를 표준화했습니다.
