### PR TITLE
Refactor/comment

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,10 +23,9 @@ public class CommentController {
     @PostMapping("/{article-id}/comments")
     public ResponseEntity<CommentResponseDto> createRootComment(
             @PathVariable("article-id") @Positive Long articleId,
-            @RequestBody @Valid CommentRequestDto dto
+            @RequestBody @Valid CommentRequestDto dto,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        Long memberId = 1L; // Todo: 임시 member id
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(commentService.createRootComment(memberId, articleId, dto));
     }
@@ -34,10 +34,9 @@ public class CommentController {
     public ResponseEntity<CommentResponseDto> createReplyComment(
             @PathVariable("article-id") @Positive Long articleId,
             @PathVariable("parent-comment-id") @Positive Long parentCommentId,
-            @RequestBody @Valid CommentRequestDto dto
+            @RequestBody @Valid CommentRequestDto dto,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        Long memberId = 1L; // Todo: 임시 member id
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(commentService.createReplyComment(memberId, articleId, parentCommentId, dto));
     }
@@ -45,19 +44,18 @@ public class CommentController {
     @PatchMapping("/comments/{comment-id}")
     public ResponseEntity<CommentResponseDto> updateComment(
             @PathVariable("comment-id") @Positive Long commentId,
-            @RequestBody @Valid CommentRequestDto dto
+            @RequestBody @Valid CommentRequestDto dto,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        Long memberId = 1L; // Todo: 임시 member id
-
         return ResponseEntity.status(HttpStatus.OK)
                 .body(commentService.updateComment(commentId, memberId, dto));
     }
 
     @DeleteMapping("/comments/{comment-id}")
     public ResponseEntity<Void> deleteComment(
-            @PathVariable("comment-id") @Positive Long commentId
+            @PathVariable("comment-id") @Positive Long commentId,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        Long memberId = 1L; // Todo: 임시 member id
         commentService.deleteComment(commentId, memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/entity/Comment.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/entity/Comment.java
@@ -3,14 +3,15 @@ package com.mobble.mobbleserver.domain.comment.entity;
 import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
 import com.mobble.mobbleserver.domain.article.entity.Article;
 import com.mobble.mobbleserver.domain.member.entity.Member;
-import com.mobble.mobbleserver.global.exception.errorCode.comment.CommentErrorCode;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.comment.CommentErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -39,7 +40,7 @@ public class Comment extends BaseEntity {
     private String content;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> children;
+    private List<Comment> children =  new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Comment(

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/repository/CommentRepository.java
@@ -2,7 +2,6 @@ package com.mobble.mobbleserver.domain.comment.repository;
 
 import com.mobble.mobbleserver.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,6 +12,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     Optional<Comment> findByIdAndMemberId(Long commentId, Long memberId);
 
-    @Modifying
     void deleteAllCommentByArticle_IdIn(List<Long> articleIds);
 }


### PR DESCRIPTION
## 📄 refactor: CommentController 인증 처리 및 Comment 엔티티/레포지토리 개선

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #127 

## ✅ 변경 사항
- CommentController에서 임시 memberId 제거 후 @AuthenticationPrincipal(expression = "memberId")로 실제 인증된 사용자 ID 주입
- CommentRepository 삭제 메서드에서 불필요한 @Modifying 어노테이션 제거
- Comment 엔티티의 children 컬렉션 초기화를 null → new ArrayList<>()로 변경하여 NPE 방지 및 JPA 관례 준수

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 📝 기타 사항
- 불필요한 어노테이션 제거로 코드 가독성과 유지보수성이 개선
