### PR TITLE
Test/club entity

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -100,3 +100,30 @@ class ClubTest {
                     .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
         }
     }
+
+    @Nested
+    @DisplayName("클럽 수정 테스트")
+    class UpdateClub {
+
+        @Test
+        @DisplayName("정상 수정")
+        void update_success() {
+            // given
+            ClubCategory newCategory = ClubCategoryTestFixture.createDefaultCategory();
+            String newName = "서울 주말 풋살 클럽";
+            String newGround = "상암 월드컵경기장 풋살장";
+            String newAddress = "서울시 마포구 월드컵로 240";
+            int newHeadCount = 30;
+            boolean newIsAutoJoin = false;
+
+            // when
+            mockClub.updateClub(newCategory, newName, newGround, newAddress, newHeadCount, newIsAutoJoin);
+
+            // then
+            assertThat(mockClub.getClubCategory()).isEqualTo(newCategory);
+            assertThat(mockClub.getName()).isEqualTo(newName);
+            assertThat(mockClub.getGround()).isEqualTo(newGround);
+            assertThat(mockClub.getAddress()).isEqualTo(newAddress);
+            assertThat(mockClub.getHeadCount()).isEqualTo(newHeadCount);
+            assertThat(mockClub.isAutoJoin()).isFalse();
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -43,3 +43,11 @@ class ClubTest {
             assertThat(club.getHeadCount()).isEqualTo(headCount);
             assertThat(club.isAutoJoin()).isTrue();
         }
+
+        @Test
+        @DisplayName("category == null → 예외")
+        void create_fail_when_category_null() {
+            assertThatThrownBy(() -> Club.createClub(null, name, ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.CATEGORY_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -1,0 +1,26 @@
+package com.mobble.mobbleserver.domain.club.core.entity;
+
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.clubCategory.ClubCategoryTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class ClubTest {
+
+    private final ClubCategory mockCategory = ClubCategoryTestFixture.createDefaultCategory();
+    private final Club mockClub = ClubTestFixture.createDefaultClub(mockCategory);
+
+    private final String name = "서울 취미 축구 클럽";
+    private final String ground = "잠실종합운동장 보조구장";
+    private final String address = "서울시 송파구 올림픽로 25";
+    private final int headCount = 20;
+    private final boolean isAutoJoin = true;

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -184,3 +184,23 @@ class ClubTest {
                     .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
         }
     }
+
+    @Nested
+    @DisplayName("연관 관계 편의 메서드")
+    class AssociationHelper {
+
+        @Test
+        @DisplayName("setClubChatRoomInternal 정상 동작")
+        void setClubChatRoomInternal_success() {
+            // given
+            Club club = Club.createClub(mockCategory, name, ground, address, headCount, isAutoJoin);
+            ClubChatRoom chatRoom = mock(ClubChatRoom.class);
+
+            // when
+            club.setClubChatRoomInternal(chatRoom);
+
+            // then
+            assertThat(club.getClubChatRoom()).isSameAs(chatRoom);
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -75,3 +75,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("address null/blank → 예외")
+        void create_fail_when_address_invalid() {
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, ground, null, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
+
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, ground, "   ", headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -51,3 +51,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.CATEGORY_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("name null/blank → 예외")
+        void create_fail_when_name_invalid() {
+            assertThatThrownBy(() -> Club.createClub(mockCategory, null, ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
+
+            assertThatThrownBy(() -> Club.createClub(mockCategory, "   ", ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -159,3 +159,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("address null/blank → 예외")
+        void update_fail_when_address_invalid() {
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, null, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
+
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, "   ", headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -147,3 +147,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("ground null/blank → 예외")
+        void update_fail_when_ground_invalid() {
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, null, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
+
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, "   ", address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -63,3 +63,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("ground null/blank → 예외")
+        void create_fail_when_ground_invalid() {
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, null, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
+
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, "   ", address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -171,3 +171,16 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("headCount <= 0 → 예외")
+        void update_fail_when_headcount_invalid() {
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, address, 0, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
+
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, address, -5, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -24,3 +24,22 @@ class ClubTest {
     private final String address = "서울시 송파구 올림픽로 25";
     private final int headCount = 20;
     private final boolean isAutoJoin = true;
+
+    @Nested
+    @DisplayName("클럽 생성 테스트")
+    class CreateClub {
+
+        @Test
+        @DisplayName("정상 생성")
+        void create_success() {
+            // given & when
+            Club club = Club.createClub(mockCategory, name, ground, address, headCount, isAutoJoin);
+
+            // then
+            assertThat(club.getClubCategory()).isEqualTo(mockCategory);
+            assertThat(club.getName()).isEqualTo(name);
+            assertThat(club.getGround()).isEqualTo(ground);
+            assertThat(club.getAddress()).isEqualTo(address);
+            assertThat(club.getHeadCount()).isEqualTo(headCount);
+            assertThat(club.isAutoJoin()).isTrue();
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -127,62 +127,6 @@ class ClubTest {
             assertThat(mockClub.getHeadCount()).isEqualTo(newHeadCount);
             assertThat(mockClub.isAutoJoin()).isFalse();
         }
-
-        @Test
-        @DisplayName("category == null → 예외")
-        void update_fail_when_category_null() {
-            assertThatThrownBy(() -> mockClub.updateClub(null, name, ground, address, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.CATEGORY_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("name null/blank → 예외")
-        void update_fail_when_name_invalid() {
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, null, ground, address, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
-
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, "   ", ground, address, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("ground null/blank → 예외")
-        void update_fail_when_ground_invalid() {
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, null, address, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
-
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, "   ", address, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.GROUND_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("address null/blank → 예외")
-        void update_fail_when_address_invalid() {
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, null, headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
-
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, "   ", headCount, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("headCount <= 0 → 예외")
-        void update_fail_when_headcount_invalid() {
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, address, 0, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
-
-            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, name, ground, address, -5, isAutoJoin))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
-        }
     }
 
     @Nested

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -127,3 +127,11 @@ class ClubTest {
             assertThat(mockClub.getHeadCount()).isEqualTo(newHeadCount);
             assertThat(mockClub.isAutoJoin()).isFalse();
         }
+
+        @Test
+        @DisplayName("category == null → 예외")
+        void update_fail_when_category_null() {
+            assertThatThrownBy(() -> mockClub.updateClub(null, name, ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.CATEGORY_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -135,3 +135,15 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.CATEGORY_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("name null/blank → 예외")
+        void update_fail_when_name_invalid() {
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, null, ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
+
+            assertThatThrownBy(() -> mockClub.updateClub(mockCategory, "   ", ground, address, headCount, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.NAME_REQUIRED.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/entity/ClubTest.java
@@ -87,3 +87,16 @@ class ClubTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.ADDRESS_REQUIRED.message());
         }
+
+        @Test
+        @DisplayName("headCount <= 0 → 예외")
+        void create_fail_when_headcount_invalid() {
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, ground, address, 0, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
+
+            assertThatThrownBy(() -> Club.createClub(mockCategory, name, ground, address, -1, isAutoJoin))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.HEADCOUNT_REQUIRED.message());
+        }
+    }


### PR DESCRIPTION
## 📄 Test: Club 도메인 단위 테스트 

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #129 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
### Club 도메인 단위 테스트 추가 (ClubTest)
  - 생성(Create): ```category/name/ground/address/headCount``` 유효성 검증 및 예외 메시지 검증 (```ClubErrorCode```기준)
    - ```category == null``` → ```CATEGORY_REQUIRED```
    - ```name/ground/address null 또는 blank``` → 각 ```*_REQUIRED```
    - ```headCount <= 0``` → ```HEADCOUNT_REQUIRED```
  - 수정(Update): ```category/name/ground/address/headCount```변경 성공 및 각 필드 유효성/예외 검증
  - 연관 관계(Association): ```setClubChatRoomInternal``` 호출 시 ```club.getClubChatRoom()```과 동일 객체로 설정되는지 확인

### 테스트 가독성 향상
 - ```@Nested```, ```@DisplayName``` 구조화
 - AssertJ 사용으로 명확한 검증 (```isEqualTo```, ```isSameAs```, ```hasMessage``` 등)
 - 예외는 ```DomainException``` 타입 및 ```*.message()```로 정확한 메시지까지 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인