### PR TITLE
Refactor/meeting d day

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -17,11 +17,11 @@ public record MeetingResponseDto(
         String cost,
         Integer memberLimit,
         int attendeeCount,
-        MeetingType type
-//        String dDay //Todo d-day 추가
+        MeetingType type,
+        String dDay
 ) {
     
-    public static MeetingResponseDto toDto(Meeting meeting, int attendeeCount) {
+    public static MeetingResponseDto toDto(Meeting meeting, int attendeeCount, String dDay) {
         return new MeetingResponseDto(
                 meeting.getId(),
                 meeting.getClubMember().getClub().getId(),
@@ -31,8 +31,8 @@ public record MeetingResponseDto(
                 meeting.getCost(),
                 meeting.getMemberLimit(),
                 attendeeCount,
-                meeting.getType()
-//                dDay
+                meeting.getType(),
+                dDay
         );
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/dto/response/MeetingResponseDto.java
@@ -18,10 +18,10 @@ public record MeetingResponseDto(
         Integer memberLimit,
         int attendeeCount,
         MeetingType type,
-        String dDay
+        int dDay
 ) {
     
-    public static MeetingResponseDto toDto(Meeting meeting, int attendeeCount, String dDay) {
+    public static MeetingResponseDto toDto(Meeting meeting, int attendeeCount, int dDay) {
         return new MeetingResponseDto(
                 meeting.getId(),
                 meeting.getClubMember().getClub().getId(),

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -27,21 +30,25 @@ public class MeetingService {
         ClubMember hostMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
 
         Meeting meeting = dto.toEntity(hostMember);
-        //Todo d-day 표시 추가
 
         Meeting saveMeeting = meetingRepository.save(meeting);
-        int attendeeCount = 0;
 
-        return MeetingResponseDto.toDto(saveMeeting, attendeeCount);
+        int attendeeCount = 0;
+        String dDay = calculateDDay(saveMeeting.getDatetime());
+
+        return MeetingResponseDto.toDto(saveMeeting, attendeeCount, dDay);
     }
 
     public List<MeetingResponseDto> findMeetingsByClubId(Long memberId, Long clubId) {
         clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId);
         List<Meeting> meetings = meetingRepository.findByClubMember_Club_Id(clubId);
 
-
         return meetings.stream()
-                .map(meeting -> MeetingResponseDto.toDto(meeting, meeting.getMeetingMembers().size()))
+                .map(meeting -> {
+                    int attendeeCount = meeting.getMeetingMembers().size();
+                    String dDay = calculateDDay(meeting.getDatetime());
+                    return MeetingResponseDto.toDto(meeting, attendeeCount, dDay);
+                })
                 .toList();
     }
 
@@ -66,8 +73,9 @@ public class MeetingService {
 
         Meeting updateMeeting = meetingRepository.save(meeting);
         int attendeeCount = meeting.getMeetingMembers().size();
+        String dDay = calculateDDay(updateMeeting.getDatetime());
 
-        return MeetingResponseDto.toDto(updateMeeting, attendeeCount);
+        return MeetingResponseDto.toDto(updateMeeting, attendeeCount, dDay);
     }
 
     @Transactional

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -87,4 +87,21 @@ public class MeetingService {
         return meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException(""));
     }
+
+    /**
+     * D-day 계산용 메서드
+     */
+    private String calculateDDay(LocalDateTime meetingDateTime) {
+        LocalDate today = LocalDate.now();
+        LocalDate meetingDate = meetingDateTime.toLocalDate();
+        long days = Duration.between(today.atStartOfDay(), meetingDate.atStartOfDay()).toDays();
+
+        if (days > 0) {
+            return "D-" + days;
+        } else if (days == 0) {
+            return "D-Day";
+        } else {
+            return "D+" + Math.abs(days);
+        }
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -93,9 +93,6 @@ public class MeetingService {
         meetingRepository.delete(meeting);
     }
 
-    /**
-     * D-day 계산용 메서드
-     */
     private String calculateDDay(LocalDateTime meetingDateTime) {
         LocalDate today = LocalDate.now();
         LocalDate meetingDate = meetingDateTime.toLocalDate();

--- a/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meeting/service/MeetingService.java
@@ -36,7 +36,7 @@ public class MeetingService {
         Meeting saveMeeting = meetingRepository.save(meeting);
 
         int attendeeCount = 0;
-        String dDay = calculateDDay(saveMeeting.getDatetime());
+        int dDay = calculateDDay(saveMeeting.getDatetime());
 
         return MeetingResponseDto.toDto(saveMeeting, attendeeCount, dDay);
     }
@@ -48,7 +48,7 @@ public class MeetingService {
         return meetings.stream()
                 .map(meeting -> {
                     int attendeeCount = meeting.getMeetingMembers().size();
-                    String dDay = calculateDDay(meeting.getDatetime());
+                    int dDay = calculateDDay(meeting.getDatetime());
                     return MeetingResponseDto.toDto(meeting, attendeeCount, dDay);
                 })
                 .toList();
@@ -75,7 +75,7 @@ public class MeetingService {
 
         Meeting updateMeeting = meetingRepository.save(meeting);
         int attendeeCount = meeting.getMeetingMembers().size();
-        String dDay = calculateDDay(updateMeeting.getDatetime());
+        int dDay = calculateDDay(updateMeeting.getDatetime());
 
         return MeetingResponseDto.toDto(updateMeeting, attendeeCount, dDay);
     }
@@ -93,17 +93,10 @@ public class MeetingService {
         meetingRepository.delete(meeting);
     }
 
-    private String calculateDDay(LocalDateTime meetingDateTime) {
+    private int calculateDDay(LocalDateTime meetingDateTime) {
         LocalDate today = LocalDate.now();
         LocalDate meetingDate = meetingDateTime.toLocalDate();
-        long days = Duration.between(today.atStartOfDay(), meetingDate.atStartOfDay()).toDays();
 
-        if (days > 0) {
-            return "D-" + days;
-        } else if (days == 0) {
-            return "D-Day";
-        } else {
-            return "D+" + Math.abs(days);
-        }
+        return (int) Duration.between(today.atStartOfDay(), meetingDate.atStartOfDay()).toDays();
     }
 }


### PR DESCRIPTION
## 📄 Meeting 반환 시 D-day 노출 기능
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #133 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MeetingResponseDto: dDay 필드 추가
- MeetingService: 모임 날짜 기준 D-day 계산 로직(calculateDDay) 구현, MeetingResponseDto.toDto(...) dDay 파라미터 전달

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->
- D-day 계산 방식 및 return 방식이 적절한지

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- @Scheduled 기반 지난 모임 자동 삭제 기능 구현 고려