### PR TITLE
Refactor/comment

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
@@ -15,12 +15,12 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles")
+@RequestMapping("/articles/{article-id}/comments")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/{article-id}/comments")
+    @PostMapping
     public ResponseEntity<CommentResponseDto> createRootComment(
             @PathVariable("article-id") @Positive Long articleId,
             @RequestBody @Valid CommentRequestDto dto,
@@ -30,7 +30,7 @@ public class CommentController {
                 .body(commentService.createRootComment(memberId, articleId, dto));
     }
 
-    @PostMapping("/{article-id}/comments/{parent-comment-id}/replies")
+    @PostMapping("/{parent-comment-id}/replies")
     public ResponseEntity<CommentResponseDto> createReplyComment(
             @PathVariable("article-id") @Positive Long articleId,
             @PathVariable("parent-comment-id") @Positive Long parentCommentId,
@@ -41,22 +41,24 @@ public class CommentController {
                 .body(commentService.createReplyComment(memberId, articleId, parentCommentId, dto));
     }
 
-    @PatchMapping("/comments/{comment-id}")
+    @PatchMapping("/{comment-id}")
     public ResponseEntity<CommentResponseDto> updateComment(
+            @PathVariable("article-id") @Positive Long articleId,
             @PathVariable("comment-id") @Positive Long commentId,
             @RequestBody @Valid CommentRequestDto dto,
             @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(commentService.updateComment(commentId, memberId, dto));
+                .body(commentService.updateComment(articleId, commentId, memberId, dto));
     }
 
-    @DeleteMapping("/comments/{comment-id}")
+    @DeleteMapping("/{comment-id}")
     public ResponseEntity<Void> deleteComment(
+            @PathVariable("article-id") @Positive Long articleId,
             @PathVariable("comment-id") @Positive Long commentId,
             @AuthenticationPrincipal(expression = "memberId") Long memberId
     ) {
-        commentService.deleteComment(commentId, memberId);
+        commentService.deleteComment(articleId, commentId, memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/controller/CommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles/{article-id}/comments")
+@RequestMapping("/api/articles/{article-id}/comments")
 public class CommentController {
 
     private final CommentService commentService;

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
@@ -2,6 +2,8 @@ package com.mobble.mobbleserver.domain.comment.service;
 
 import com.mobble.mobbleserver.domain.article.entity.Article;
 import com.mobble.mobbleserver.domain.article.validator.ArticleValidator;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.policy.ClubPermissionPolicy;
 import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.comment.dto.request.CommentRequestDto;
@@ -62,16 +64,41 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponseDto updateComment(Long commentId, Long memberId, CommentRequestDto dto) {
-        Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
+    public CommentResponseDto updateComment(
+            Long articleId,
+            Long commentId,
+            Long memberId,
+            CommentRequestDto dto
+    ) {
+        Article article = articleValidator.findArticleByArticleIdOrThrow(articleId);
+        Club club = article.getClub();
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(club.getId(), memberId);
+        Member member = clubMember.getMember();
+        Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, member.getId());
+
+        if (!comment.getArticle().getId().equals(articleId)) throw new IllegalArgumentException("");
+
         Comment updatedComment = comment.updateContent(dto.content());
 
         return CommentResponseDto.toDto(updatedComment);
     }
 
     @Transactional
-    public void deleteComment(Long commentId, Long memberId) {
-        Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
+    public void deleteComment(Long articleId, Long commentId, Long memberId) {
+        Article article = articleValidator.findArticleByArticleIdOrThrow(articleId);
+        Club club = article.getClub();
+        ClubMember clubMember = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(club.getId(), memberId);
+
+        Comment comment;
+
+        if (ClubPermissionPolicy.isLeaderOrManager(clubMember)) {
+            comment = commentValidator.findCommentByCommentIdOrThrow(commentId);
+        } else {
+            comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
+        }
+
+        if (!comment.getArticle().getId().equals(articleId)) throw new IllegalArgumentException("");
+
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
@@ -3,7 +3,7 @@ package com.mobble.mobbleserver.domain.comment.service;
 import com.mobble.mobbleserver.domain.article.entity.Article;
 import com.mobble.mobbleserver.domain.article.validator.ArticleValidator;
 import com.mobble.mobbleserver.domain.club.core.entity.Club;
-import com.mobble.mobbleserver.domain.club.core.policy.ClubPermissionPolicy;
+import com.mobble.mobbleserver.domain.club.policy.ClubPermissionPolicy;
 import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.comment.dto.request.CommentRequestDto;

--- a/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/comment/service/CommentService.java
@@ -14,6 +14,8 @@ import com.mobble.mobbleserver.domain.comment.repository.CommentRepository;
 import com.mobble.mobbleserver.domain.comment.repository.dto.CommentLikeInfoDto;
 import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.comment.CommentErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +78,7 @@ public class CommentService {
         Member member = clubMember.getMember();
         Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, member.getId());
 
-        if (!comment.getArticle().getId().equals(articleId)) throw new IllegalArgumentException("");
+        validateCommentByArticleIdOrThrow(comment, article.getId());
 
         Comment updatedComment = comment.updateContent(dto.content());
 
@@ -97,7 +99,7 @@ public class CommentService {
             comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
         }
 
-        if (!comment.getArticle().getId().equals(articleId)) throw new IllegalArgumentException("");
+        validateCommentByArticleIdOrThrow(comment, article.getId());
 
         commentRepository.delete(comment);
     }
@@ -122,5 +124,9 @@ public class CommentService {
                 .toList();
 
         return commentRepository.findLikeInfoByCommentIdsAndMemberId(commentIds, memberId);
+    }
+
+    private void validateCommentByArticleIdOrThrow(Comment comment, Long articleId) {
+        if (!comment.getArticle().getId().equals(articleId)) throw new DomainException(CommentErrorCode.ARTICLE_REQUIRED);
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/entity/CommentTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/entity/CommentTest.java
@@ -19,7 +19,7 @@ class CommentTest {
     private final Comment mockComment = CommentTestFixture.createDefaultRootComment();
     private final Member mockMember = MemberTestFixture.createDefaultMember();
     private final Article mockArticle = ArticleTestFixture.createDefaultArticle();
-    private final String content = "content";
+    private static final String CONTENT = "content";
 
     @Nested
     @DisplayName("댓글 생성 테스트")
@@ -29,12 +29,12 @@ class CommentTest {
         @DisplayName("루트 댓글 생성 성공")
         void success_when_create_root_comment() {
             // given & when
-            Comment rootComment = Comment.createRootComment(mockMember, mockArticle, content);
+            Comment rootComment = Comment.createRootComment(mockMember, mockArticle, CONTENT);
 
             // then
             assertThat(rootComment.getMember()).isEqualTo(mockMember);
             assertThat(rootComment.getArticle()).isEqualTo(mockArticle);
-            assertThat(rootComment.getContent()).isEqualTo(content);
+            assertThat(rootComment.getContent()).isEqualTo(CONTENT);
             assertThat(rootComment.hasParent()).isFalse();
         }
 
@@ -42,13 +42,13 @@ class CommentTest {
         @DisplayName("대댓글 생성 성공")
         void success_when_create_reply_comment() {
             // given & when
-            Comment rootComment = Comment.createRootComment(mockMember, mockArticle, content);
-            Comment replyComment = Comment.createReplyComment(mockMember, mockArticle, rootComment, content);
+            Comment rootComment = Comment.createRootComment(mockMember, mockArticle, CONTENT);
+            Comment replyComment = Comment.createReplyComment(mockMember, mockArticle, rootComment, CONTENT);
 
             // then
             assertThat(replyComment.getMember()).isEqualTo(mockMember);
             assertThat(replyComment.getArticle()).isEqualTo(mockArticle);
-            assertThat(replyComment.getContent()).isEqualTo(content);
+            assertThat(replyComment.getContent()).isEqualTo(CONTENT);
             assertThat(replyComment.getParent()).isEqualTo(rootComment);
             assertThat(replyComment.hasParent()).isTrue();
         }
@@ -57,7 +57,7 @@ class CommentTest {
         @DisplayName("대댓글의 루트 댓글이 null 인 경우 예외 발생")
         void fails_when_create_reply_comment_parent_is_null() {
             // when & then
-            assertThatThrownBy(() -> Comment.createReplyComment(mockMember, mockArticle, null, content))
+            assertThatThrownBy(() -> Comment.createReplyComment(mockMember, mockArticle, null, CONTENT))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(CommentErrorCode.PARENT_REQUIRED.message());
         }
@@ -104,7 +104,7 @@ class CommentTest {
         @DisplayName("member 가 null 인 경우 예외 발생")
         void fails_with_null_member() {
             // when & then
-            assertThatThrownBy(() -> Comment.createRootComment(null, mockArticle, content))
+            assertThatThrownBy(() -> Comment.createRootComment(null, mockArticle, CONTENT))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(CommentErrorCode.MEMBER_REQUIRED.message());
         }
@@ -113,7 +113,7 @@ class CommentTest {
         @DisplayName("article 이 null 인 경우 예외 발생")
         void fails_with_null_article() {
             // when & then
-            assertThatThrownBy(() -> Comment.createRootComment(mockMember, null, content))
+            assertThatThrownBy(() -> Comment.createRootComment(mockMember, null, CONTENT))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(CommentErrorCode.ARTICLE_REQUIRED.message());
         }

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import com.mobble.mobbleserver.domain.article.entity.Article;
 import com.mobble.mobbleserver.domain.article.validator.ArticleValidator;
 import com.mobble.mobbleserver.domain.club.core.entity.Club;
 import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.comment.dto.request.CommentRequestDto;
 import com.mobble.mobbleserver.domain.comment.dto.response.CommentResponseDto;
@@ -15,6 +16,7 @@ import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.comment.CommentErrorCode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,8 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -52,6 +53,33 @@ class CommentServiceTest {
     @InjectMocks
     private CommentService commentService;
 
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long ARTICLE_ID = 3L;
+    private static final Long COMMENT_ID = 4L;
+    private static final Long PARENT_COMMENT_ID = 5L;
+    private static final Long LEADER_MEMBER_ID = 6L;
+    private static final Long MANAGER_MEMBER_ID = 7L;
+
+    private Club mockClub;
+    private Article mockArticle;
+    private Member mockMember;
+    private Comment mockComment;
+    private ClubMember mockClubMember;
+    private ClubMember mockLeader;
+    private ClubMember mockManager;
+
+    @BeforeEach
+    void setUp() {
+        mockClub = mock(Club.class);
+        mockArticle = mock(Article.class);
+        mockMember = mock(Member.class);
+        mockComment = mock(Comment.class);
+        mockClubMember = mock(ClubMember.class);
+        mockLeader = mock(ClubMember.class);
+        mockManager = mock(ClubMember.class);
+    }
+
     @Nested
     @DisplayName("댓글 생성")
     class CreateComment {
@@ -60,31 +88,23 @@ class CommentServiceTest {
         @DisplayName("루트 댓글 생성 성공")
         void success_when_create_root_comment() {
             // given
-            Long clubId = 1L;
-            Long memberId = 2L;
-            Long articleId = 3L;
+            Comment mockRootComment = mock(Comment.class);
             CommentRequestDto dto = new CommentRequestDto("content");
 
-            Club mockClub = mock(Club.class);
-            Member mockMember = mock(Member.class);
-            Article mockArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
-            Comment mockRootComment = mock(Comment.class);
-
             given(mockArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
             given(mockClubMember.getMember()).willReturn(mockMember);
 
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
 
             given(commentRepository.save(any())).willReturn(mockRootComment);
             given(mockRootComment.getMember()).willReturn(mockMember);
             given(mockRootComment.getArticle()).willReturn(mockArticle);
 
             // when
-            CommentResponseDto rootComment = commentService.createRootComment(memberId, articleId, dto);
+            CommentResponseDto rootComment = commentService.createRootComment(MEMBER_ID, ARTICLE_ID, dto);
 
             // then
             assertThat(rootComment).isNotNull();
@@ -95,35 +115,26 @@ class CommentServiceTest {
         @DisplayName("대댓글 생성 성공")
         void success_when_create_reply_comment() {
             // given
-            Long clubId = 1L;
-            Long memberId = 2L;
-            Long articleId = 3L;
-            Long parentId = 4L;
-            CommentRequestDto dto = new CommentRequestDto("content");
-
-            Club mockClub = mock(Club.class);
-            Member mockMember = mock(Member.class);
-            Article mockArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
             Comment mockParentComment = mock(Comment.class);
             Comment mockReplyComment = mock(Comment.class);
+            CommentRequestDto dto = new CommentRequestDto("content");
 
             given(mockArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
             given(mockClubMember.getMember()).willReturn(mockMember);
 
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
 
-            given(commentValidator.findCommentByCommentIdOrThrow(parentId)).willReturn(mockParentComment);
+            given(commentValidator.findCommentByCommentIdOrThrow(PARENT_COMMENT_ID)).willReturn(mockParentComment);
 
             given(commentRepository.save(any())).willReturn(mockReplyComment);
             given(mockReplyComment.getMember()).willReturn(mockMember);
             given(mockReplyComment.getArticle()).willReturn(mockArticle);
 
             // when
-            CommentResponseDto replyComment = commentService.createReplyComment(memberId, articleId, parentId, dto);
+            CommentResponseDto replyComment = commentService.createReplyComment(MEMBER_ID, ARTICLE_ID, PARENT_COMMENT_ID, dto);
 
             // then
             assertThat(replyComment).isNotNull();
@@ -139,42 +150,32 @@ class CommentServiceTest {
         @DisplayName("댓글 수정 성공")
         void success_when_update_comment() {
             // given
-            Long clubId = 1L;
-            Long articleId = 2L;
-            Long memberId = 3L;
-            Long commentId = 4L;
+            Comment mockUpdatedComment = mock(Comment.class);
             CommentRequestDto dto = new CommentRequestDto("update content");
 
-            Club mockClub = mock(Club.class);
-            Article mockArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
-            Member mockMember = mock(Member.class);
-            Comment mockComment = mock(Comment.class);
-            Comment mockUpdatedComment = mock(Comment.class);
-
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
             given(mockArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
             given(mockClubMember.getMember()).willReturn(mockMember);
-            given(mockMember.getId()).willReturn(memberId);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
 
-            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID)).willReturn(mockComment);
 
             given(mockComment.getArticle()).willReturn(mockArticle);
-            given(mockArticle.getId()).willReturn(articleId);
+            given(mockArticle.getId()).willReturn(ARTICLE_ID);
 
             given(mockComment.updateContent(dto.content())).willReturn(mockUpdatedComment);
             given(mockUpdatedComment.getMember()).willReturn(mockMember);
             given(mockUpdatedComment.getArticle()).willReturn(mockArticle);
 
             // when
-            CommentResponseDto response = commentService.updateComment(articleId, commentId, memberId, dto);
+            CommentResponseDto response = commentService.updateComment(ARTICLE_ID, COMMENT_ID, MEMBER_ID, dto);
 
             // then
             assertThat(response).isNotNull();
-            verify(commentValidator).findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
+            verify(commentValidator).findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID);
             verify(mockComment).updateContent(dto.content());
         }
 
@@ -182,35 +183,26 @@ class CommentServiceTest {
         @DisplayName("댓글 수정 실패 - 다른 게시글의 댓글")
         void fail_when_update_comment_article_mismatch() {
             // given
-            Long clubId = 1L;
-            Long articleId = 2L;
-            Long otherArticleId = 3L;
-            Long commentId = 4L;
-            Long memberId = 5L;
-            CommentRequestDto dto = new CommentRequestDto("update content");
-
-            Club mockClub = mock(Club.class);
+            Long otherArticleId = 100L;
             Article mockRequestedArticle = mock(Article.class);
             Article mockOtherArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
-            Member mockMember = mock(Member.class);
-            Comment mockComment = mock(Comment.class);
+            CommentRequestDto dto = new CommentRequestDto("update content");
 
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockRequestedArticle);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockRequestedArticle);
             given(mockRequestedArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
             given(mockClubMember.getMember()).willReturn(mockMember);
-            given(mockMember.getId()).willReturn(memberId);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
 
-            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID)).willReturn(mockComment);
 
             given(mockComment.getArticle()).willReturn(mockOtherArticle);
             given(mockOtherArticle.getId()).willReturn(otherArticleId);
 
             // when & then
-            assertThatThrownBy(() -> commentService.updateComment(articleId, commentId, memberId, dto))
+            assertThatThrownBy(() -> commentService.updateComment(ARTICLE_ID, COMMENT_ID, MEMBER_ID, dto))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(CommentErrorCode.ARTICLE_REQUIRED.message());
         }
@@ -224,32 +216,98 @@ class CommentServiceTest {
         @DisplayName("댓글 삭제 성공 - 일반 멤버가 자신의 댓글 삭제")
         void success_when_delete_comment() {
             // given
-            Long memberId = 1L;
-            Long commentId = 2L;
-            Long clubId = 3L;
-            Long articleId = 4L;
-
-            Comment mockComment = mock(Comment.class);
-            Club mockClub = mock(Club.class);
-            Article mockArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
-
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
-            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID)).willReturn(mockComment);
             given(mockArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
 
-            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID)).willReturn(mockComment);
 
             given(mockComment.getArticle()).willReturn(mockArticle);
-            given(mockArticle.getId()).willReturn(articleId);
+            given(mockArticle.getId()).willReturn(ARTICLE_ID);
 
             // when
-            commentService.deleteComment(articleId, commentId, memberId);
+            commentService.deleteComment(ARTICLE_ID, COMMENT_ID, MEMBER_ID);
 
             // then
             verify(commentRepository).delete(mockComment);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 성공 - 리더가 타인 댓글 삭제")
+        void success_when_leader_deletes_others_comment() {
+            // given
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+            given(mockArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(CLUB_ID);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_MEMBER_ID)).willReturn(mockLeader);
+            given(mockLeader.getClubMemberRole()).willReturn(ClubMemberRole.LEADER);
+
+            given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+
+            given(mockComment.getArticle()).willReturn(mockArticle);
+            given(mockArticle.getId()).willReturn(ARTICLE_ID);
+
+            // when
+            commentService.deleteComment(ARTICLE_ID, COMMENT_ID, LEADER_MEMBER_ID);
+
+            // then
+            verify(commentRepository).delete(mockComment);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 성공 - 매니저가 타인 댓글 삭제")
+        void success_when_manager_deletes_others_comment() {
+            // given
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+            given(mockArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(CLUB_ID);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MANAGER_MEMBER_ID)).willReturn(mockManager);
+            given(mockManager.getClubMemberRole()).willReturn(ClubMemberRole.MANAGER);
+
+            given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+
+            given(mockComment.getArticle()).willReturn(mockArticle);
+            given(mockArticle.getId()).willReturn(ARTICLE_ID);
+
+            // when
+            commentService.deleteComment(ARTICLE_ID, COMMENT_ID, MANAGER_MEMBER_ID);
+
+            // then
+            verify(commentRepository).delete(mockComment);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 실패 - 리더라도 다른 게시글의 댓글이면 실패")
+        void fail_when_leader_deletes_comment_of_another_article() {
+            // given
+            Long requestArticleId = 50L;
+            Long realArticleId = 100L;
+
+            Article mockRequestedArticle = mock(Article.class);
+            Article mockOtherArticle = mock(Article.class);
+
+            given(articleValidator.findArticleByArticleIdOrThrow(requestArticleId)).willReturn(mockRequestedArticle);
+            given(mockRequestedArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(CLUB_ID);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_MEMBER_ID)).willReturn(mockLeader);
+            given(mockLeader.getClubMemberRole()).willReturn(ClubMemberRole.LEADER);
+
+            given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+
+            given(mockComment.getArticle()).willReturn(mockOtherArticle);
+            given(mockOtherArticle.getId()).willReturn(realArticleId);
+
+            // when & then
+            assertThatThrownBy(() -> commentService.deleteComment(requestArticleId, COMMENT_ID, LEADER_MEMBER_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(CommentErrorCode.ARTICLE_REQUIRED.message());
+
+            verify(commentRepository, never()).delete(any());
         }
     }
 
@@ -261,27 +319,20 @@ class CommentServiceTest {
         @DisplayName("특정 게시글의 댓글 리스트(좋아요 정보 포함) 조회 성공")
         void success_when_get_comment_list_by_article() {
             // given
-            Long articleId = 1L;
-            Long memberId = 2L;
-
-            Article mockArticle = mock(Article.class);
-            Member mockMember = mock(Member.class);
-            Comment mockComment = mock(Comment.class);
-
-            given(mockArticle.getId()).willReturn(articleId);
-            given(mockMember.getId()).willReturn(memberId);
+            given(mockArticle.getId()).willReturn(ARTICLE_ID);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
             given(mockComment.getId()).willReturn(100L);
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
 
-            given(commentRepository.findCommentsWithRepliesByArticleId(articleId)).willReturn(List.of(mockComment));
+            given(commentRepository.findCommentsWithRepliesByArticleId(ARTICLE_ID)).willReturn(List.of(mockComment));
             given(mockComment.getMember()).willReturn(mockMember);
             given(mockComment.getArticle()).willReturn(mockArticle);
 
             CommentLikeInfoDto likeInfoDto = CommentLikeInfoDto.toDto(2, true);
-            given(commentRepository.findLikeInfoByCommentIdsAndMemberId(any(), eq(memberId))).willReturn(Map.of(100L, likeInfoDto));
+            given(commentRepository.findLikeInfoByCommentIdsAndMemberId(any(), eq(MEMBER_ID))).willReturn(Map.of(100L, likeInfoDto));
 
             // when
-            List<RootCommentResponseDto> response = commentService.getCommentListByArticle(articleId, memberId);
+            List<RootCommentResponseDto> response = commentService.getCommentListByArticle(ARTICLE_ID, MEMBER_ID);
 
             // then
             assertThat(response).hasSize(1);
@@ -290,8 +341,8 @@ class CommentServiceTest {
             assertThat(dto.likeCount()).isEqualTo(2);
             assertThat(dto.isLiked()).isTrue();
 
-            verify(commentRepository).findCommentsWithRepliesByArticleId(articleId);
-            verify(commentRepository).findLikeInfoByCommentIdsAndMemberId(any(), eq(memberId));
+            verify(commentRepository).findCommentsWithRepliesByArticleId(ARTICLE_ID);
+            verify(commentRepository).findLikeInfoByCommentIdsAndMemberId(any(), eq(MEMBER_ID));
         }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -136,27 +137,112 @@ class CommentServiceTest {
         @DisplayName("댓글 수정 성공")
         void success_when_update_comment() {
             // given
-            Long memberId = 1L;
-            Long commentId = 2L;
+            Long clubId = 1L;
+            Long articleId = 2L;
+            Long memberId = 3L;
+            Long commentId = 4L;
             CommentRequestDto dto = new CommentRequestDto("update content");
 
-            Member mockMember = mock(Member.class);
+            Club mockClub = mock(Club.class);
             Article mockArticle = mock(Article.class);
+            ClubMember mockClubMember = mock(ClubMember.class);
+            Member mockMember = mock(Member.class);
             Comment mockComment = mock(Comment.class);
             Comment mockUpdatedComment = mock(Comment.class);
 
+            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(mockArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(clubId);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(mockClubMember.getMember()).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(memberId);
+
             given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+
+            given(mockComment.getArticle()).willReturn(mockArticle);
+            given(mockArticle.getId()).willReturn(articleId);
+
             given(mockComment.updateContent(dto.content())).willReturn(mockUpdatedComment);
             given(mockUpdatedComment.getMember()).willReturn(mockMember);
             given(mockUpdatedComment.getArticle()).willReturn(mockArticle);
 
             // when
-            CommentResponseDto response = commentService.updateComment(commentId, memberId, dto);
+            CommentResponseDto response = commentService.updateComment(articleId, commentId, memberId, dto);
 
             // then
             assertThat(response).isNotNull();
             verify(commentValidator).findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
             verify(mockComment).updateContent(dto.content());
+        }
+
+        @Test
+        @DisplayName("댓글 수정 실패 - 다른 게시글의 댓글")
+        void fail_when_update_comment_article_mismatch() {
+            // given
+            Long clubId = 1L;
+            Long articleId = 2L;
+            Long otherArticleId = 3L;
+            Long commentId = 4L;
+            Long memberId = 5L;
+            CommentRequestDto dto = new CommentRequestDto("update content");
+
+            Club mockClub = mock(Club.class);
+            Article mockRequestedArticle = mock(Article.class);
+            Article mockOtherArticle = mock(Article.class);
+            ClubMember mockClubMember = mock(ClubMember.class);
+            Member mockMember = mock(Member.class);
+            Comment mockComment = mock(Comment.class);
+
+            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockRequestedArticle);
+            given(mockRequestedArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(clubId);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(mockClubMember.getMember()).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(memberId);
+
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+
+            given(mockComment.getArticle()).willReturn(mockOtherArticle);
+            given(mockOtherArticle.getId()).willReturn(otherArticleId);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> commentService.updateComment(articleId, commentId, memberId, dto)
+            ).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 수정 실패 - 본인 댓글이 아님")
+        void fail_when_update_comment_not_owner() {
+            // given
+            Long clubId = 1L;
+            Long articleId = 2L;
+            Long commentId = 3L;
+            Long memberId = 4L;
+            CommentRequestDto dto = new CommentRequestDto("update content");
+
+            Club mockClub = mock(Club.class);
+            Article mockArticle = mock(Article.class);
+            ClubMember mockClubMember = mock(ClubMember.class);
+            Member mockMember = mock(Member.class);
+
+            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(mockArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(clubId);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
+            given(mockClubMember.getMember()).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(memberId);
+
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId))
+                    .willThrow(new IllegalArgumentException("No permission to update this comment"));
+
+            // when & then
+            assertThatThrownBy(
+                    () -> commentService.updateComment(articleId, commentId, memberId, dto)
+            ).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -165,21 +251,34 @@ class CommentServiceTest {
     class DeleteComment {
 
         @Test
-        @DisplayName("댓글 삭제 성공")
+        @DisplayName("댓글 삭제 성공 - 일반 멤버가 자신의 댓글 삭제")
         void success_when_delete_comment() {
             // given
             Long memberId = 1L;
             Long commentId = 2L;
+            Long clubId = 3L;
+            Long articleId = 4L;
 
             Comment mockComment = mock(Comment.class);
+            Club mockClub = mock(Club.class);
+            Article mockArticle = mock(Article.class);
+            ClubMember mockClubMember = mock(ClubMember.class);
+
+            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
+            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
+            given(mockArticle.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(clubId);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
 
             given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId)).willReturn(mockComment);
 
+            given(mockComment.getArticle()).willReturn(mockArticle);
+            given(mockArticle.getId()).willReturn(articleId);
+
             // when
-            commentService.deleteComment(commentId, memberId);
+            commentService.deleteComment(articleId, commentId, memberId);
 
             // then
-            verify(commentValidator).findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
             verify(commentRepository).delete(mockComment);
         }
     }

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
@@ -214,38 +214,6 @@ class CommentServiceTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(CommentErrorCode.ARTICLE_REQUIRED.message());
         }
-
-        @Test
-        @DisplayName("댓글 수정 실패 - 본인 댓글이 아님")
-        void fail_when_update_comment_not_owner() {
-            // given
-            Long clubId = 1L;
-            Long articleId = 2L;
-            Long commentId = 3L;
-            Long memberId = 4L;
-            CommentRequestDto dto = new CommentRequestDto("update content");
-
-            Club mockClub = mock(Club.class);
-            Article mockArticle = mock(Article.class);
-            ClubMember mockClubMember = mock(ClubMember.class);
-            Member mockMember = mock(Member.class);
-
-            given(articleValidator.findArticleByArticleIdOrThrow(articleId)).willReturn(mockArticle);
-            given(mockArticle.getClub()).willReturn(mockClub);
-            given(mockClub.getId()).willReturn(clubId);
-
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(mockClubMember);
-            given(mockClubMember.getMember()).willReturn(mockMember);
-            given(mockMember.getId()).willReturn(memberId);
-
-            given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId))
-                    .willThrow(new DomainException(CommentErrorCode.NO_PERMISSION));
-
-            // when & then
-            assertThatThrownBy(() -> commentService.updateComment(articleId, commentId, memberId, dto))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(CommentErrorCode.NO_PERMISSION.message());
-        }
     }
 
     @Nested

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/service/CommentServiceTest.java
@@ -13,6 +13,8 @@ import com.mobble.mobbleserver.domain.comment.repository.CommentRepository;
 import com.mobble.mobbleserver.domain.comment.repository.dto.CommentLikeInfoDto;
 import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.comment.CommentErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -208,9 +210,9 @@ class CommentServiceTest {
             given(mockOtherArticle.getId()).willReturn(otherArticleId);
 
             // when & then
-            assertThatThrownBy(
-                    () -> commentService.updateComment(articleId, commentId, memberId, dto)
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> commentService.updateComment(articleId, commentId, memberId, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(CommentErrorCode.ARTICLE_REQUIRED.message());
         }
 
         @Test
@@ -237,12 +239,12 @@ class CommentServiceTest {
             given(mockMember.getId()).willReturn(memberId);
 
             given(commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId))
-                    .willThrow(new IllegalArgumentException("No permission to update this comment"));
+                    .willThrow(new DomainException(CommentErrorCode.NO_PERMISSION));
 
             // when & then
-            assertThatThrownBy(
-                    () -> commentService.updateComment(articleId, commentId, memberId, dto)
-            ).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> commentService.updateComment(articleId, commentId, memberId, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(CommentErrorCode.NO_PERMISSION.message());
         }
     }
 

--- a/src/test/java/com/mobble/mobbleserver/domain/comment/validator/CommentValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/comment/validator/CommentValidatorTest.java
@@ -27,16 +27,19 @@ class CommentValidatorTest {
     @InjectMocks
     private CommentValidator commentValidator;
 
+    private static final Long COMMENT_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+
     @Test
     @DisplayName("댓글 ID 로 조회 성공")
     void success_when_find_comment_or_Throw() {
         // given
-        Long commentId = 1L;
         Comment mockComment = mock(Comment.class);
-        when(commentRepository.findById(commentId)).thenReturn(Optional.of(mockComment));
+
+        when(commentRepository.findById(COMMENT_ID)).thenReturn(Optional.of(mockComment));
 
         // when
-        Comment comment = commentValidator.findCommentByCommentIdOrThrow(commentId);
+        Comment comment = commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID);
 
         // then
         assertThat(comment).isEqualTo(mockComment);
@@ -46,11 +49,10 @@ class CommentValidatorTest {
     @DisplayName("댓글 ID 로 조회 실패 시 예외 발생")
     void fails_when_find_comment_or_throw() {
         // given
-        Long commentId = 1L;
-        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+        when(commentRepository.findById(COMMENT_ID)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentValidator.findCommentByCommentIdOrThrow(commentId))
+        assertThatThrownBy(() -> commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(CommentErrorCode.NOT_FOUND.message());
     }
@@ -59,13 +61,12 @@ class CommentValidatorTest {
     @DisplayName("댓글 ID 와 멤버 ID 로 조회 성공")
     void success_when_find_comment_by_id_and_member_or_throw() {
         // given
-        Long commentId = 1L;
-        Long memberId = 2L;
         Comment mockComment = mock(Comment.class);
-        when(commentRepository.findByIdAndMemberId(commentId, memberId)).thenReturn(Optional.of(mockComment));
+
+        when(commentRepository.findByIdAndMemberId(COMMENT_ID, MEMBER_ID)).thenReturn(Optional.of(mockComment));
 
         // when
-        Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId);
+        Comment comment = commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID);
 
         // then
         assertThat(comment).isEqualTo(mockComment);
@@ -75,12 +76,10 @@ class CommentValidatorTest {
     @DisplayName("댓글 ID 와 멤버 ID 로 조회 실패 시 예외 발생")
     void fail_find_comment_by_id_and_member_or_throw() {
         // given
-        Long commentId = 1L;
-        Long memberId = 2L;
-        when(commentRepository.findByIdAndMemberId(commentId, memberId)).thenReturn(Optional.empty());
+        when(commentRepository.findByIdAndMemberId(COMMENT_ID, MEMBER_ID)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentValidator.findCommentByCommentIdAndMemberIdOrThrow(commentId, memberId))
+        assertThatThrownBy(() -> commentValidator.findCommentByCommentIdAndMemberIdOrThrow(COMMENT_ID, MEMBER_ID))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(CommentErrorCode.NO_PERMISSION.message());
     }


### PR DESCRIPTION
## 📄 refactor: Comment update/delete 검증 및 권한 기반 삭제 기능 추가, 테스트 코드 리팩토링

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #140 

## ✅ 변경 사항
- CommentService
    - updateComment, deleteComment 메서드에 게시글 일치 검증 로직 추가
    - deleteComment에서 리더/매니저 권한 보유 시 타인 댓글 삭제 허용 기능 추가
    - 공통 가드 메서드 validateCommentByArticleIdOrThrow 추가
- 테스트 코드
    - service/validator 테스트에서 공통 상수(CLUB_ID, ARTICLE_ID 등) 분리 및 정의
    - 반복되는 mock 객체를 @BeforeEach에서 공통 초기화하도록 리팩토링
    - deleteComment 권한 검증 관련 테스트 케이스 추가
    - 일반 멤버: 본인 댓글만 삭제 가능
    - 리더/매니저: 타인 댓글 삭제 가능
    - 리더/매니저라도 다른 게시글의 댓글은 삭제 불가

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인
