### PR TITLE
Test/club service

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -112,8 +112,6 @@ public class ClubService {
 
         clubChatRoomService.deleteClubChatRoom(club.getId());
 
-        clubLikeRepository.deleteClubLikeAllByClub_Id(club.getId());
-
         List<Long> articleIds = articleRepository.findArticleIdsByClubId(club.getId());
 
         commentLikeRepository.deleteAllCommentLikeByComment_Article_IdIn(articleIds);

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -138,3 +138,19 @@ class ClubServiceTest {
             verify(clubChatRoomService).createClubChatRoom(nullable(Long.class), eq(memberId));
             verify(clubRepository).findLikeInfoByClubIdAndMemberId(any(), eq(memberId));
         }
+
+        @Test
+        @DisplayName("실패 - 잘못된 카테고리")
+        void fail_when_category_not_found() {
+            // given
+            Long memberId = 1L;
+            ClubRequestDto dto = mock(ClubRequestDto.class);
+            given(dto.category()).willReturn("UNKNOWN");
+            given(clubCategoryRepository.findByName("UNKNOWN")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> clubService.createClub(memberId, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.CATEGORY_NOT_FOUND.message());
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -277,3 +277,29 @@ class ClubServiceTest {
             verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
         }
     }
+
+    @Test
+    @DisplayName("수정 실패 - 리더가 아님")
+    void fail_when_not_leader() {
+        // given
+        Long clubId = 1L;
+        Long memberId = 2L;
+
+        Club club = mock(Club.class);
+        Member member = mock(Member.class);
+        ClubMember clubMember = mock(ClubMember.class);
+        ClubRequestDto dto = mock(ClubRequestDto.class);
+
+        given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
+        given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(member);
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
+        given(clubMember.isLeader()).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> clubService.updateClub(clubId, memberId, dto))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
+
+        verify(clubRepository, never()).findLikeInfoByClubIdAndMemberId(anyLong(), anyLong());
+        verify(ageGroupRepository, never()).deleteAllClubAgeGroupByClubId(anyLong());
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -303,3 +303,52 @@ class ClubServiceTest {
         verify(clubRepository, never()).findLikeInfoByClubIdAndMemberId(anyLong(), anyLong());
         verify(ageGroupRepository, never()).deleteAllClubAgeGroupByClubId(anyLong());
     }
+    @DisplayName("클럽 삭제")
+    class DeleteClub {
+
+        @Test
+        @DisplayName("삭제 성공 - 리더가 삭제, 연쇄 삭제 순서 검증")
+        void success_delete_by_leader() {
+            // given
+            Long clubId = 77L;
+            Long memberId = 88L;
+
+            ClubMember clubMember = mock(ClubMember.class);
+            Club club = mock(Club.class);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
+
+            given(clubMember.isLeader()).willReturn(true);
+            given(clubMember.getClub()).willReturn(club);
+            given(club.getId()).willReturn(clubId);
+
+            List<Long> articleIds = List.of(100L, 200L);
+            given(articleRepository.findArticleIdsByClubId(clubId)).willReturn(articleIds);
+
+            // when
+            clubService.deleteClub(clubId, memberId);
+
+            // then
+            InOrder inOrder = inOrder(
+                    clubChatRoomService,
+                    clubLikeRepository,
+                    articleRepository,
+                    commentLikeRepository,
+                    commentRepository,
+                    articleLikeRepository,
+                    clubMemberRepository,
+                    ageGroupRepository,
+                    clubRepository
+            );
+
+            inOrder.verify(clubChatRoomService).deleteClubChatRoom(clubId);
+            inOrder.verify(clubLikeRepository).deleteClubLikeAllByClub_Id(clubId);
+            inOrder.verify(articleRepository).findArticleIdsByClubId(clubId);
+            inOrder.verify(commentLikeRepository).deleteAllCommentLikeByComment_Article_IdIn(articleIds);
+            inOrder.verify(commentRepository).deleteAllCommentByArticle_IdIn(articleIds);
+            inOrder.verify(articleLikeRepository).deleteAllArticleLikeByArticle_IdIn(articleIds);
+            inOrder.verify(articleRepository).deleteAllArticleByClub_Id(clubId);
+            inOrder.verify(clubMemberRepository).deleteAllClubMemberByClubId(clubId);
+            inOrder.verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
+            inOrder.verify(clubRepository).deleteById(clubId);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -344,13 +344,13 @@ class ClubServiceTest {
             );
 
             inOrder.verify(clubChatRoomService).deleteClubChatRoom(clubId);
-            inOrder.verify(clubLikeRepository).deleteClubLikeAllByClub_Id(clubId);
             inOrder.verify(articleRepository).findArticleIdsByClubId(clubId);
             inOrder.verify(commentLikeRepository).deleteAllCommentLikeByComment_Article_IdIn(articleIds);
             inOrder.verify(commentRepository).deleteAllCommentByArticle_IdIn(articleIds);
             inOrder.verify(articleLikeRepository).deleteAllArticleLikeByArticle_IdIn(articleIds);
             inOrder.verify(articleRepository).deleteAllArticleByClub_Id(clubId);
             inOrder.verify(clubMemberRepository).deleteAllClubMemberByClubId(clubId);
+            inOrder.verify(clubLikeRepository).deleteClubLikeAllByClub_Id(clubId);
             inOrder.verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
             inOrder.verify(clubRepository).deleteById(clubId);
         }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -1,0 +1,50 @@
+package com.mobble.mobbleserver.domain.club.core.service;
+
+import com.mobble.mobbleserver.domain.article.repository.ArticleRepository;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.dto.response.ClubChatRoomPreviewResponseDto;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.service.ClubChatRoomService;
+import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroup;
+import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroupType;
+import com.mobble.mobbleserver.domain.club.ageGroup.repository.AgeGroupRepository;
+import com.mobble.mobbleserver.domain.club.core.dto.request.ClubRequestDto;
+import com.mobble.mobbleserver.domain.club.core.dto.response.ClubResponseDto;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.repository.ClubRepository;
+import com.mobble.mobbleserver.domain.club.core.repository.dto.ClubLikeInfoDto;
+import com.mobble.mobbleserver.domain.club.core.validator.ClubValidator;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.clubCategory.repository.ClubCategoryRepository;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
+import com.mobble.mobbleserver.domain.clubMember.repository.ClubMemberRepository;
+import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
+import com.mobble.mobbleserver.domain.comment.repository.CommentRepository;
+import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
+import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
+import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubServiceTest {

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -222,3 +222,58 @@ class ClubServiceTest {
             verifyNoInteractions(memberValidator);
         }
     }
+
+    @Nested
+    @DisplayName("클럽 수정")
+    class UpdateClub {
+
+        @Test
+        @DisplayName("수정 성공 - 리더가 수정, 연령대 재구성")
+        void success_update_by_leader() {
+            // given
+            Long clubId = 10L;
+            Long memberId = 20L;
+
+            Club club = mock(Club.class);
+            Member member = mock(Member.class);
+            ClubMember clubMember = mock(ClubMember.class);
+            ClubCategory category = mock(ClubCategory.class);
+
+            List<AgeGroupType> ages = List.of(AgeGroupType.THIRTIES, AgeGroupType.FORTIES);
+            ClubRequestDto dto = new ClubRequestDto("name", "SOCCER", "ground", "address", 3, ages, true);
+
+            given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
+            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(member);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
+            given(clubCategoryRepository.findByName(dto.category())).willReturn(Optional.of(category));
+            given(clubMember.isLeader()).willReturn(true);
+
+            given(club.getId()).willReturn(clubId);
+            given(member.getId()).willReturn(memberId);
+
+            given(club.getClubCategory()).willReturn(category);
+            given(category.getName()).willReturn("SOCCER");
+            given(club.getName()).willReturn("name");
+            given(club.getGround()).willReturn("ground");
+            given(club.getAddress()).willReturn("address");
+            given(club.getHeadCount()).willReturn(3);
+            given(club.isAutoJoin()).willReturn(true);
+
+            AgeGroup ag1 = mock(AgeGroup.class);
+            AgeGroup ag2 = mock(AgeGroup.class);
+
+            given(ageGroupRepository.findByClubId(clubId)).willReturn(List.of(ag1, ag2));
+            given(ag1.getAgeGroupType()).willReturn(AgeGroupType.THIRTIES);
+            given(ag2.getAgeGroupType()).willReturn(AgeGroupType.FORTIES);
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(clubId, memberId))
+                    .willReturn(new ClubLikeInfoDto(1, false));
+
+            // when
+            ClubResponseDto res = clubService.updateClub(clubId, memberId, dto);
+
+            // then
+            assertThat(res).isNotNull();
+            verify(ageGroupRepository).saveAll(anyList());
+            verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -203,3 +203,22 @@ class ClubServiceTest {
             verify(ageGroupRepository).findByClubId(clubId);
             verify(clubRepository).findLikeInfoByClubIdAndMemberId(clubId, memberId);
         }
+
+        @Test
+        @DisplayName("단건 조회 실패 - 클럽 없음")
+        void fail_when_not_found() {
+            // given
+            Long clubId = 1L;
+            Long memberId = 2L;
+
+            DomainException ex = new DomainException(ClubErrorCode.NOT_FOUND);
+            willThrow(ex).given(clubValidator).findClubByClubIdOrThrow(clubId);
+
+            // when & then
+            assertThatThrownBy(() -> clubService.findClubById(clubId, memberId))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubErrorCode.NOT_FOUND.message());
+
+            verifyNoInteractions(memberValidator);
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -154,3 +154,52 @@ class ClubServiceTest {
                     .hasMessage(ClubErrorCode.CATEGORY_NOT_FOUND.message());
         }
     }
+
+    @Nested
+    @DisplayName("클럽 조회")
+    class GetClub {
+
+        @Test
+        @DisplayName("CLUB_ID로 조회")
+        void success_find_by_id() {
+            // given
+            Long clubId = 100L;
+            Long memberId = 200L;
+
+            Club club = mock(Club.class);
+            ClubCategory category = mock(ClubCategory.class);
+            ClubMember leader = mock(ClubMember.class);
+            Member leaderMember = mock(Member.class);
+            Member me = mock(Member.class);
+
+            given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
+            given(club.getId()).willReturn(clubId);
+
+            given(club.getClubCategory()).willReturn(category);
+
+            given(clubMemberRepository.findByClubIdAndClubMemberRole(clubId, ClubMemberRole.LEADER))
+                    .willReturn(Optional.of(leader));
+            given(leader.getMember()).willReturn(leaderMember);
+
+            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(me);
+            given(me.getId()).willReturn(memberId);
+
+            AgeGroup ag1 = mock(AgeGroup.class);
+            AgeGroup ag2 = mock(AgeGroup.class);
+            given(ageGroupRepository.findByClubId(clubId)).willReturn(List.of(ag1, ag2));
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(clubId, memberId))
+                    .willReturn(new ClubLikeInfoDto(9, false));
+
+            // when
+            ClubResponseDto res = clubService.findClubById(clubId, memberId);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.id()).isEqualTo(clubId);
+
+            verify(clubValidator).findClubByClubIdOrThrow(clubId);
+            verify(clubMemberRepository).findByClubIdAndClubMemberRole(clubId, ClubMemberRole.LEADER);
+            verify(memberValidator).findMemberByMemberIdOrThrow(memberId);
+            verify(ageGroupRepository).findByClubId(clubId);
+            verify(clubRepository).findLikeInfoByClubIdAndMemberId(clubId, memberId);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -90,3 +90,51 @@ class ClubServiceTest {
 
     @InjectMocks
     private ClubService clubService;
+
+    @Nested
+    @DisplayName("클럽 생성")
+    class CreateClub {
+
+        @Test
+        @DisplayName("성공 - 카테고리/멤버 유효, 채팅방 생성 포함")
+        void success_create_club() {
+            //given
+            Long memberId = 2L;
+
+            Member mockMember = mock(Member.class);
+            ClubCategory mockClubCategory = mock(ClubCategory.class);
+
+            List<AgeGroupType> ageGroupList = List.of(AgeGroupType.TEEN, AgeGroupType.TWENTIES);
+            ClubRequestDto dto = new ClubRequestDto("name", "SOCCER", "ground", "address", 3, ageGroupList, true);
+
+            given(clubCategoryRepository.findByName(dto.category())).willReturn(Optional.of(mockClubCategory));
+            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(memberId);
+
+            given(clubRepository.save(any(Club.class))).willAnswer(inv -> inv.getArgument(0));
+            given(clubMemberRepository.save(any(ClubMember.class))).willAnswer(inv -> inv.getArgument(0));
+
+            AgeGroup ag1 = mock(AgeGroup.class);
+            AgeGroup ag2 = mock(AgeGroup.class);
+            given(ageGroupRepository.saveAll(anyList())).willReturn(List.of(ag1, ag2));
+            given(ageGroupRepository.findByClubId(any())).willReturn(List.of(ag1, ag2));
+
+            given(clubChatRoomService.createClubChatRoom(nullable(Long.class), eq(memberId)))
+                    .willReturn(new ClubChatRoomPreviewResponseDto(123L, null, "clubName", "", null, 0, null));
+
+            ClubLikeInfoDto likeInfo = new ClubLikeInfoDto(0, false);
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(any(), eq(memberId)))
+                    .willReturn(likeInfo);
+
+            // when
+            ClubResponseDto res = clubService.createClub(memberId, dto);
+
+            // then
+            assertThat(res).isNotNull();
+            verify(clubRepository).save(any(Club.class));
+            verify(clubMemberRepository).save(any(ClubMember.class));
+            verify(ageGroupRepository).saveAll(anyList());
+            verify(ageGroupRepository).findByClubId(any());
+            verify(clubChatRoomService).createClubChatRoom(nullable(Long.class), eq(memberId));
+            verify(clubRepository).findLikeInfoByClubIdAndMemberId(any(), eq(memberId));
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -27,6 +27,7 @@ import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberErrorCode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,27 @@ class ClubServiceTest {
     @InjectMocks
     private ClubService clubService;
 
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long LEADER_MEMBER_ID = 2L;
+
+    private Club mockClub;
+    private Member mockMember;
+    private Member mockLeaderMember;
+    private ClubMember mockClubMember;
+    private ClubMember mockLeaderClubMember;
+    private ClubCategory mockClubCategory;
+
+    @BeforeEach
+    void setUp() {
+        mockClub = mock(Club.class);
+        mockMember = mock(Member.class);
+        mockLeaderMember = mock(Member.class);
+        mockClubMember = mock(ClubMember.class);
+        mockLeaderClubMember = mock(ClubMember.class);
+        mockClubCategory = mock(ClubCategory.class);
+    }
+
     @Nested
     @DisplayName("클럽 생성")
     class CreateClub {
@@ -99,17 +121,12 @@ class ClubServiceTest {
         @DisplayName("성공 - 카테고리/멤버 유효, 채팅방 생성 포함")
         void success_create_club() {
             //given
-            Long memberId = 2L;
-
-            Member mockMember = mock(Member.class);
-            ClubCategory mockClubCategory = mock(ClubCategory.class);
-
             List<AgeGroupType> ageGroupList = List.of(AgeGroupType.TEEN, AgeGroupType.TWENTIES);
             ClubRequestDto dto = new ClubRequestDto("name", "SOCCER", "ground", "address", 3, ageGroupList, true);
 
             given(clubCategoryRepository.findByName(dto.category())).willReturn(Optional.of(mockClubCategory));
-            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(mockMember);
-            given(mockMember.getId()).willReturn(memberId);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
 
             given(clubRepository.save(any(Club.class))).willAnswer(inv -> inv.getArgument(0));
             given(clubMemberRepository.save(any(ClubMember.class))).willAnswer(inv -> inv.getArgument(0));
@@ -119,15 +136,15 @@ class ClubServiceTest {
             given(ageGroupRepository.saveAll(anyList())).willReturn(List.of(ag1, ag2));
             given(ageGroupRepository.findByClubId(any())).willReturn(List.of(ag1, ag2));
 
-            given(clubChatRoomService.createClubChatRoom(nullable(Long.class), eq(memberId)))
+            given(clubChatRoomService.createClubChatRoom(nullable(Long.class), eq(MEMBER_ID)))
                     .willReturn(new ClubChatRoomPreviewResponseDto(123L, null, "clubName", "", null, 0, null));
 
             ClubLikeInfoDto likeInfo = new ClubLikeInfoDto(0, false);
-            given(clubRepository.findLikeInfoByClubIdAndMemberId(any(), eq(memberId)))
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(any(), eq(MEMBER_ID)))
                     .willReturn(likeInfo);
 
             // when
-            ClubResponseDto res = clubService.createClub(memberId, dto);
+            ClubResponseDto res = clubService.createClub(MEMBER_ID, dto);
 
             // then
             assertThat(res).isNotNull();
@@ -135,21 +152,20 @@ class ClubServiceTest {
             verify(clubMemberRepository).save(any(ClubMember.class));
             verify(ageGroupRepository).saveAll(anyList());
             verify(ageGroupRepository).findByClubId(any());
-            verify(clubChatRoomService).createClubChatRoom(nullable(Long.class), eq(memberId));
-            verify(clubRepository).findLikeInfoByClubIdAndMemberId(any(), eq(memberId));
+            verify(clubChatRoomService).createClubChatRoom(nullable(Long.class), eq(MEMBER_ID));
+            verify(clubRepository).findLikeInfoByClubIdAndMemberId(any(), eq(MEMBER_ID));
         }
 
         @Test
         @DisplayName("실패 - 잘못된 카테고리")
         void fail_when_category_not_found() {
             // given
-            Long memberId = 1L;
             ClubRequestDto dto = mock(ClubRequestDto.class);
             given(dto.category()).willReturn("UNKNOWN");
             given(clubCategoryRepository.findByName("UNKNOWN")).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> clubService.createClub(memberId, dto))
+            assertThatThrownBy(() -> clubService.createClub(MEMBER_ID, dto))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.CATEGORY_NOT_FOUND.message());
         }
@@ -163,59 +179,50 @@ class ClubServiceTest {
         @DisplayName("CLUB_ID로 조회")
         void success_find_by_id() {
             // given
-            Long clubId = 100L;
-            Long memberId = 200L;
-
-            Club club = mock(Club.class);
-            ClubCategory category = mock(ClubCategory.class);
-            ClubMember leader = mock(ClubMember.class);
             Member leaderMember = mock(Member.class);
             Member me = mock(Member.class);
 
-            given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
-            given(club.getId()).willReturn(clubId);
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
-            given(club.getClubCategory()).willReturn(category);
+            given(mockClub.getClubCategory()).willReturn(mockClubCategory);
 
-            given(clubMemberRepository.findByClubIdAndClubMemberRole(clubId, ClubMemberRole.LEADER))
-                    .willReturn(Optional.of(leader));
-            given(leader.getMember()).willReturn(leaderMember);
+            given(clubMemberRepository.findByClubIdAndClubMemberRole(CLUB_ID, ClubMemberRole.LEADER))
+                    .willReturn(Optional.of(mockLeaderClubMember));
+            given(mockLeaderClubMember.getMember()).willReturn(mockLeaderMember);
 
-            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(me);
-            given(me.getId()).willReturn(memberId);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(me);
+            given(me.getId()).willReturn(MEMBER_ID);
 
             AgeGroup ag1 = mock(AgeGroup.class);
             AgeGroup ag2 = mock(AgeGroup.class);
-            given(ageGroupRepository.findByClubId(clubId)).willReturn(List.of(ag1, ag2));
-            given(clubRepository.findLikeInfoByClubIdAndMemberId(clubId, memberId))
+            given(ageGroupRepository.findByClubId(CLUB_ID)).willReturn(List.of(ag1, ag2));
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(CLUB_ID, MEMBER_ID))
                     .willReturn(new ClubLikeInfoDto(9, false));
 
             // when
-            ClubResponseDto res = clubService.findClubById(clubId, memberId);
+            ClubResponseDto res = clubService.findClubById(CLUB_ID, MEMBER_ID);
 
             // then
             assertThat(res).isNotNull();
-            assertThat(res.id()).isEqualTo(clubId);
+            assertThat(res.id()).isEqualTo(CLUB_ID);
 
-            verify(clubValidator).findClubByClubIdOrThrow(clubId);
-            verify(clubMemberRepository).findByClubIdAndClubMemberRole(clubId, ClubMemberRole.LEADER);
-            verify(memberValidator).findMemberByMemberIdOrThrow(memberId);
-            verify(ageGroupRepository).findByClubId(clubId);
-            verify(clubRepository).findLikeInfoByClubIdAndMemberId(clubId, memberId);
+            verify(clubValidator).findClubByClubIdOrThrow(CLUB_ID);
+            verify(clubMemberRepository).findByClubIdAndClubMemberRole(CLUB_ID, ClubMemberRole.LEADER);
+            verify(memberValidator).findMemberByMemberIdOrThrow(MEMBER_ID);
+            verify(ageGroupRepository).findByClubId(CLUB_ID);
+            verify(clubRepository).findLikeInfoByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
         }
 
         @Test
         @DisplayName("단건 조회 실패 - 클럽 없음")
         void fail_when_not_found() {
             // given
-            Long clubId = 1L;
-            Long memberId = 2L;
-
             DomainException ex = new DomainException(ClubErrorCode.NOT_FOUND);
-            willThrow(ex).given(clubValidator).findClubByClubIdOrThrow(clubId);
+            willThrow(ex).given(clubValidator).findClubByClubIdOrThrow(CLUB_ID);
 
             // when & then
-            assertThatThrownBy(() -> clubService.findClubById(clubId, memberId))
+            assertThatThrownBy(() -> clubService.findClubById(CLUB_ID, MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubErrorCode.NOT_FOUND.message());
 
@@ -231,50 +238,42 @@ class ClubServiceTest {
         @DisplayName("수정 성공 - 리더가 수정, 연령대 재구성")
         void success_update_by_leader() {
             // given
-            Long clubId = 10L;
-            Long memberId = 20L;
-
-            Club club = mock(Club.class);
-            Member member = mock(Member.class);
-            ClubMember clubMember = mock(ClubMember.class);
-            ClubCategory category = mock(ClubCategory.class);
-
             List<AgeGroupType> ages = List.of(AgeGroupType.THIRTIES, AgeGroupType.FORTIES);
             ClubRequestDto dto = new ClubRequestDto("name", "SOCCER", "ground", "address", 3, ages, true);
 
-            given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
-            given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(member);
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
-            given(clubCategoryRepository.findByName(dto.category())).willReturn(Optional.of(category));
-            given(clubMember.isLeader()).willReturn(true);
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
+            given(clubCategoryRepository.findByName(dto.category())).willReturn(Optional.of(mockClubCategory));
+            given(mockClubMember.isLeader()).willReturn(true);
 
-            given(club.getId()).willReturn(clubId);
-            given(member.getId()).willReturn(memberId);
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
 
-            given(club.getClubCategory()).willReturn(category);
-            given(category.getName()).willReturn("SOCCER");
-            given(club.getName()).willReturn("name");
-            given(club.getGround()).willReturn("ground");
-            given(club.getAddress()).willReturn("address");
-            given(club.getHeadCount()).willReturn(3);
-            given(club.isAutoJoin()).willReturn(true);
+            given(mockClub.getClubCategory()).willReturn(mockClubCategory);
+            given(mockClubCategory.getName()).willReturn("SOCCER");
+            given(mockClub.getName()).willReturn("name");
+            given(mockClub.getGround()).willReturn("ground");
+            given(mockClub.getAddress()).willReturn("address");
+            given(mockClub.getHeadCount()).willReturn(3);
+            given(mockClub.isAutoJoin()).willReturn(true);
 
             AgeGroup ag1 = mock(AgeGroup.class);
             AgeGroup ag2 = mock(AgeGroup.class);
 
-            given(ageGroupRepository.findByClubId(clubId)).willReturn(List.of(ag1, ag2));
+            given(ageGroupRepository.findByClubId(CLUB_ID)).willReturn(List.of(ag1, ag2));
             given(ag1.getAgeGroupType()).willReturn(AgeGroupType.THIRTIES);
             given(ag2.getAgeGroupType()).willReturn(AgeGroupType.FORTIES);
-            given(clubRepository.findLikeInfoByClubIdAndMemberId(clubId, memberId))
+            given(clubRepository.findLikeInfoByClubIdAndMemberId(CLUB_ID, MEMBER_ID))
                     .willReturn(new ClubLikeInfoDto(1, false));
 
             // when
-            ClubResponseDto res = clubService.updateClub(clubId, memberId, dto);
+            ClubResponseDto res = clubService.updateClub(CLUB_ID, MEMBER_ID, dto);
 
             // then
             assertThat(res).isNotNull();
             verify(ageGroupRepository).saveAll(anyList());
-            verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
+            verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(CLUB_ID);
         }
     }
 
@@ -282,21 +281,15 @@ class ClubServiceTest {
     @DisplayName("수정 실패 - 리더가 아님")
     void fail_when_not_leader() {
         // given
-        Long clubId = 1L;
-        Long memberId = 2L;
-
-        Club club = mock(Club.class);
-        Member member = mock(Member.class);
-        ClubMember clubMember = mock(ClubMember.class);
         ClubRequestDto dto = mock(ClubRequestDto.class);
 
-        given(clubValidator.findClubByClubIdOrThrow(clubId)).willReturn(club);
-        given(memberValidator.findMemberByMemberIdOrThrow(memberId)).willReturn(member);
-        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
-        given(clubMember.isLeader()).willReturn(false);
+        given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+        given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
+        given(mockClubMember.isLeader()).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> clubService.updateClub(clubId, memberId, dto))
+        assertThatThrownBy(() -> clubService.updateClub(CLUB_ID, MEMBER_ID, dto))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
 
@@ -312,23 +305,17 @@ class ClubServiceTest {
         @DisplayName("삭제 성공 - 리더가 삭제, 연쇄 삭제 순서 검증")
         void success_delete_by_leader() {
             // given
-            Long clubId = 77L;
-            Long memberId = 88L;
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
 
-            ClubMember clubMember = mock(ClubMember.class);
-            Club club = mock(Club.class);
-
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(clubMember);
-
-            given(clubMember.isLeader()).willReturn(true);
-            given(clubMember.getClub()).willReturn(club);
-            given(club.getId()).willReturn(clubId);
+            given(mockClubMember.isLeader()).willReturn(true);
+            given(mockClubMember.getClub()).willReturn(mockClub);
+            given(mockClub.getId()).willReturn(CLUB_ID);
 
             List<Long> articleIds = List.of(100L, 200L);
-            given(articleRepository.findArticleIdsByClubId(clubId)).willReturn(articleIds);
+            given(articleRepository.findArticleIdsByClubId(CLUB_ID)).willReturn(articleIds);
 
             // when
-            clubService.deleteClub(clubId, memberId);
+            clubService.deleteClub(CLUB_ID, MEMBER_ID);
 
             // then
             InOrder inOrder = inOrder(
@@ -343,29 +330,25 @@ class ClubServiceTest {
                     clubRepository
             );
 
-            inOrder.verify(clubChatRoomService).deleteClubChatRoom(clubId);
-            inOrder.verify(articleRepository).findArticleIdsByClubId(clubId);
+            inOrder.verify(clubChatRoomService).deleteClubChatRoom(CLUB_ID);
+            inOrder.verify(articleRepository).findArticleIdsByClubId(CLUB_ID);
             inOrder.verify(commentLikeRepository).deleteAllCommentLikeByComment_Article_IdIn(articleIds);
             inOrder.verify(commentRepository).deleteAllCommentByArticle_IdIn(articleIds);
             inOrder.verify(articleLikeRepository).deleteAllArticleLikeByArticle_IdIn(articleIds);
-            inOrder.verify(articleRepository).deleteAllArticleByClub_Id(clubId);
-            inOrder.verify(clubMemberRepository).deleteAllClubMemberByClubId(clubId);
-            inOrder.verify(clubLikeRepository).deleteClubLikeAllByClub_Id(clubId);
-            inOrder.verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
-            inOrder.verify(clubRepository).deleteById(clubId);
+            inOrder.verify(articleRepository).deleteAllArticleByClub_Id(CLUB_ID);
+            inOrder.verify(clubMemberRepository).deleteAllClubMemberByClubId(CLUB_ID);
+            inOrder.verify(clubLikeRepository).deleteClubLikeAllByClub_Id(CLUB_ID);
+            inOrder.verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(CLUB_ID);
+            inOrder.verify(clubRepository).deleteById(CLUB_ID);
         }
 
         @Test
         @DisplayName("삭제 실패 - 리더가 아님")
         void fail_delete_when_not_leader() {
-            Long clubId = 10L;
-            Long memberId = 20L;
-            ClubMember cm = mock(ClubMember.class);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
+            given(mockClubMember.isLeader()).willReturn(false);
 
-            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(cm);
-            given(cm.isLeader()).willReturn(false);
-
-            assertThatThrownBy(() -> clubService.deleteClub(clubId, memberId))
+            assertThatThrownBy(() -> clubService.deleteClub(CLUB_ID, MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
 

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -303,6 +303,8 @@ class ClubServiceTest {
         verify(clubRepository, never()).findLikeInfoByClubIdAndMemberId(anyLong(), anyLong());
         verify(ageGroupRepository, never()).deleteAllClubAgeGroupByClubId(anyLong());
     }
+
+    @Nested
     @DisplayName("클럽 삭제")
     class DeleteClub {
 
@@ -352,3 +354,24 @@ class ClubServiceTest {
             inOrder.verify(ageGroupRepository).deleteAllClubAgeGroupByClubId(clubId);
             inOrder.verify(clubRepository).deleteById(clubId);
         }
+
+        @Test
+        @DisplayName("삭제 실패 - 리더가 아님")
+        void fail_delete_when_not_leader() {
+            Long clubId = 10L;
+            Long memberId = 20L;
+            ClubMember cm = mock(ClubMember.class);
+
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, memberId)).willReturn(cm);
+            given(cm.isLeader()).willReturn(false);
+
+            assertThatThrownBy(() -> clubService.deleteClub(clubId, memberId))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
+
+            verifyNoInteractions(clubChatRoomService, articleRepository, commentLikeRepository,
+                    commentRepository, articleLikeRepository, clubMemberRepository, ageGroupRepository,
+                    clubRepository);
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -48,3 +48,45 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ClubServiceTest {
+
+    @Mock
+    private ClubChatRoomService clubChatRoomService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubCategoryRepository clubCategoryRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private AgeGroupRepository ageGroupRepository;
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
+
+    @Mock
+    private ClubLikeRepository clubLikeRepository;
+
+    @Mock
+    private ClubValidator clubValidator;
+
+    @Mock
+    private MemberValidator memberValidator;
+
+    @Mock
+    private ClubMemberValidator clubMemberValidator;
+
+    @InjectMocks
+    private ClubService clubService;


### PR DESCRIPTION
## 📄 Test: ClubService 단위 테스트
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #142 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```ClubServiceTest``` 작성: 생성/조회/수정/삭제 성공·실패 케이스 추가
- ```생성```: 정상, ```잘못된 카테고리로 인한 실패```
- ```조회```: 정상, ```잘못된 Id```
- ```수정```: 정상, ```리더가 아닌경우```
- ```삭제```: 정상, ```리더가 아닌경우```
- ```기타```: ClubService 삭제 메서드에서 ```중복 메서드``` 제거

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->
- createClub에서 채팅방 생성 호출 인자 매칭(nullable(Long.class), eq(memberId)) 처리 적절성

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
article servic Test 와 최대한 동일 하게 진행하였음.
