### PR TITLE
Test/club validator

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/service/ClubServiceTest.java
@@ -94,7 +94,6 @@ class ClubServiceTest {
 
     private static final Long CLUB_ID = 1L;
     private static final Long MEMBER_ID = 2L;
-    private static final Long LEADER_MEMBER_ID = 2L;
 
     private Club mockClub;
     private Member mockMember;
@@ -179,9 +178,6 @@ class ClubServiceTest {
         @DisplayName("CLUB_ID로 조회")
         void success_find_by_id() {
             // given
-            Member leaderMember = mock(Member.class);
-            Member me = mock(Member.class);
-
             given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
             given(mockClub.getId()).willReturn(CLUB_ID);
 
@@ -191,8 +187,8 @@ class ClubServiceTest {
                     .willReturn(Optional.of(mockLeaderClubMember));
             given(mockLeaderClubMember.getMember()).willReturn(mockLeaderMember);
 
-            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(me);
-            given(me.getId()).willReturn(MEMBER_ID);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(mockMember.getId()).willReturn(MEMBER_ID);
 
             AgeGroup ag1 = mock(AgeGroup.class);
             AgeGroup ag2 = mock(AgeGroup.class);

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
@@ -36,3 +36,17 @@ class ClubValidatorTest {
     void setUp() {
         mockClub = mock(Club.class);
     }
+
+    @Test
+    @DisplayName("클럽 ID로 조회 성공")
+    void success_when_find_club_or_throw() {
+        // given
+        given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(mockClub));
+
+        // when
+        Club club = clubValidator.findClubByClubIdOrThrow(CLUB_ID);
+
+        // then
+        assertThat(club).isEqualTo(mockClub);
+        verify(clubRepository, times(1)).findById(CLUB_ID);
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
@@ -50,3 +50,18 @@ class ClubValidatorTest {
         assertThat(club).isEqualTo(mockClub);
         verify(clubRepository, times(1)).findById(CLUB_ID);
     }
+
+    @Test
+    @DisplayName("클럽 ID로 조회 실패 시 예외 발생")
+    void fails_when_find_club_or_throw() {
+        // given
+        given(clubRepository.findById(CLUB_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> clubValidator.findClubByClubIdOrThrow(CLUB_ID))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ClubErrorCode.NOT_FOUND.message());
+
+        verify(clubRepository, times(1)).findById(CLUB_ID);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/club/core/validator/ClubValidatorTest.java
@@ -1,0 +1,38 @@
+package com.mobble.mobbleserver.domain.club.core.validator;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.repository.ClubRepository;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubValidatorTest {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @InjectMocks
+    private ClubValidator clubValidator;
+
+    private static final Long CLUB_ID = 1L;
+
+    private Club mockClub;
+
+    @BeforeEach
+    void setUp() {
+        mockClub = mock(Club.class);
+    }


### PR DESCRIPTION
## 📄 ClubValidator 단위 테스트 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #144 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```ClubValidatorTest``` 추가
  -  ```findClubByClubIdOrThrow``` 성공 케이스: ```ClubRepository.findById```가 ```Optional.of``` 반환 시 정상 반환 검증
  - 실패 케이스: ```Optional.empty``` 시 ```DomainException(ClubErrorCode.NOT_FOUND)``` 발생 및 메시지 검증

## 📸 화면 캡처 (선택)
<!-- UI 변경이 있다면 스크린샷 첨부 -->

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

