### PR TITLE
Refactor/social login apple

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("com.auth0:java-jwt:4.4.0")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 

--- a/src/main/java/com/mobble/mobbleserver/account/appleDev/AppleCallbackController.java
+++ b/src/main/java/com/mobble/mobbleserver/account/appleDev/AppleCallbackController.java
@@ -1,0 +1,26 @@
+package com.mobble.mobbleserver.account.appleDev;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/apple")
+public class AppleCallbackController {
+
+    @PostMapping("/callback")
+    public ResponseEntity<String> appleCallback(
+            @RequestParam String id_token
+    ) {
+        log.info("🍏 Apple id_token: {}", id_token);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("✅ code & id_token 수신 완료\n\n " + id_token);
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/account/auth/controller/dev/AppleCallbackController.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/controller/dev/AppleCallbackController.java
@@ -1,7 +1,6 @@
 package com.mobble.mobbleserver.account.auth.controller.dev;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/apple")
@@ -17,10 +15,10 @@ public class AppleCallbackController {
 
     @PostMapping("/callback")
     public ResponseEntity<String> appleCallback(
-            @RequestParam String id_token
+            @RequestParam String id_token,
+            @RequestParam String code // code 를 받지 않으면 apple 에서 거절
     ) {
-        log.info("🍏 Apple id_token: {}", id_token);
         return ResponseEntity.status(HttpStatus.OK)
-                .body("✅ code & id_token 수신 완료\n\n " + id_token);
+                .build();
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/account/auth/controller/dev/AppleCallbackController.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/controller/dev/AppleCallbackController.java
@@ -1,4 +1,4 @@
-package com.mobble.mobbleserver.account.appleDev;
+package com.mobble.mobbleserver.account.auth.controller.dev;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
@@ -6,6 +6,9 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import jakarta.validation.constraints.*;
 
 public record SignUpRequestDto(
+        @NotBlank(message = "MEMBER:NAME_NOT_BLANK")
+        String name,
+
         @Min(value = 1, message = "MEMBER:AGE_TOO_LOW")
         @Max(value = 100, message = "MEMBER:AGE_TOO_HIGH")
         int age,
@@ -31,7 +34,7 @@ public record SignUpRequestDto(
 
     public Member toEntity(SocialUserInfo userInfo) {
         return Member.createMember(
-                userInfo.name(),
+                this.name(),
                 this.age,
                 this.gender,
                 userInfo.email(),

--- a/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
@@ -34,7 +34,7 @@ public record SignUpRequestDto(
 
     public Member toEntity(SocialUserInfo userInfo) {
         return Member.createMember(
-                this.name(),
+                this.name,
                 this.age,
                 this.gender,
                 userInfo.email(),

--- a/src/main/java/com/mobble/mobbleserver/account/auth/dto/response/SignUpDetailsInfoResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/dto/response/SignUpDetailsInfoResponseDto.java
@@ -4,7 +4,6 @@ import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.dto.SocialUserInfo;
 
 public record SignUpDetailsInfoResponseDto(
-        String name,
         String email,
         SocialProvider socialProvider,
         String socialId
@@ -12,7 +11,6 @@ public record SignUpDetailsInfoResponseDto(
 
     public static SignUpDetailsInfoResponseDto toDto(SocialUserInfo userInfo) {
         return new SignUpDetailsInfoResponseDto(
-                userInfo.name(),
                 userInfo.email(),
                 userInfo.socialProvider(),
                 userInfo.socialId()

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/dto/response/AppleUserInfoResponse.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/dto/response/AppleUserInfoResponse.java
@@ -1,0 +1,41 @@
+package com.mobble.mobbleserver.account.auth.oauth.dto.response;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.oAuth.OAuthErrorCode;
+
+
+public class AppleUserInfoResponse implements OAuth2UserInfo {
+
+    private final DecodedJWT jwt;
+
+    private final SocialProvider socialProvider = SocialProvider.APPLE;
+
+    public AppleUserInfoResponse(DecodedJWT jwt) {
+        if (jwt == null || jwt.getSubject() == null) throw new DomainException(OAuthErrorCode.NO_USER_INFO);
+        this.jwt = jwt;
+    }
+
+    @Override
+    public SocialProvider getProvider() {
+        return socialProvider;
+    }
+
+    @Override
+    public String getProviderId() {
+        return jwt.getSubject();
+    }
+
+    @Override
+    public String getName() {
+        // Apple은 이름을 제공하지 않으므로 null 반환 (본인인증으로 대체)
+        return null;
+    }
+
+    @Override
+    public String getEmail() {
+        // null 체크X (첫 로그인 시만 email 제공 그 이후는 제공 안 함)
+        return jwt.getClaim("email").asString();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/service/SocialProvider.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/service/SocialProvider.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public enum SocialProvider {
     KAKAO,
     NAVER,
-    GOOGLE;
+    GOOGLE,
+    APPLE;
 
     @JsonCreator
     public static SocialProvider fromString(String socialProvider) {

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/SocialVerifierFactory.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/SocialVerifierFactory.java
@@ -1,6 +1,7 @@
 package com.mobble.mobbleserver.account.auth.oauth.verifier;
 
 import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
+import com.mobble.mobbleserver.account.auth.oauth.verifier.provider.AppleTokenVerifier;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.provider.GoogleTokenVerifier;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.provider.KakaoTokenVerifier;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.provider.NaverTokenVerifier;
@@ -14,12 +15,14 @@ public class SocialVerifierFactory {
     private final KakaoTokenVerifier kakaoTokenVerifier;
     private final NaverTokenVerifier naverTokenVerifier;
     private final GoogleTokenVerifier googleTokenVerifier;
+    private final AppleTokenVerifier appleTokenVerifier;
 
     public SocialVerifier getVerifier(SocialProvider socialProvider) {
         return switch (socialProvider) {
             case KAKAO -> kakaoTokenVerifier;
             case NAVER -> naverTokenVerifier;
             case GOOGLE -> googleTokenVerifier;
+            case APPLE -> appleTokenVerifier;
         };
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/dto/SocialUserInfo.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/dto/SocialUserInfo.java
@@ -3,7 +3,6 @@ package com.mobble.mobbleserver.account.auth.oauth.verifier.dto;
 import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
 
 public record SocialUserInfo(
-        String name,
         String email,
         SocialProvider socialProvider,
         String socialId

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
@@ -50,7 +50,6 @@ public class AppleTokenVerifier implements SocialVerifier {
             AppleUserInfoResponse userInfo = new AppleUserInfoResponse(jwt);
 
             return new SocialUserInfo(
-                    userInfo.getName(),
                     userInfo.getEmail(),
                     userInfo.getProvider(),
                     userInfo.getProviderId()

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
@@ -1,0 +1,93 @@
+package com.mobble.mobbleserver.account.auth.oauth.verifier.provider;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mobble.mobbleserver.account.auth.oauth.dto.response.AppleUserInfoResponse;
+import com.mobble.mobbleserver.account.auth.oauth.verifier.SocialVerifier;
+import com.mobble.mobbleserver.account.auth.oauth.verifier.dto.SocialUserInfo;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.oAuth.OAuthErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class AppleTokenVerifier implements SocialVerifier {
+
+    private final RestClient appleRestClient;
+    private final MemberValidator memberValidator;
+
+    @Override
+    public SocialUserInfo verify(String idToken) {
+        try {
+            // 전달받은 id_token 디코드 (검증 전 상태)
+            DecodedJWT jwt = JWT.decode(idToken);
+
+            // Apple의 공개키(JWK Set)를 가져와서 key ID(kid)가 일치하는 키를 찾음
+            JsonNode keys = appleRestClient.get()
+                    .uri("https://appleid.apple.com/auth/keys")
+                    .retrieve()
+                    .body(JsonNode.class)
+                    .get("keys");
+
+            JsonNode matchingKey = findMatchingKey(keys, jwt.getKeyId());
+
+            // JWK를 기반으로 RSA 공개키 생성
+            RSAPublicKey publicKey = buildPublicKey(matchingKey);
+
+            // Apple이 서명한 id_token이 이 공개키로 유효한지 검증
+            Algorithm algorithm = Algorithm.RSA256(publicKey, null);
+            algorithm.verify(jwt); // 서명 검증 실패 시 예외 발생
+
+            AppleUserInfoResponse userInfo = new AppleUserInfoResponse(jwt);
+
+            return new SocialUserInfo(
+                    userInfo.getName(),
+                    userInfo.getEmail(),
+                    userInfo.getProvider(),
+                    userInfo.getProviderId()
+            );
+        } catch (Exception e) {
+            throw new DomainException(OAuthErrorCode.FAILED_TO_REQUEST_USER_INFO);
+        }
+    }
+
+    /**
+     * Apple의 JWK Set에서 JWT의 kid와 일치하는 키를 찾아 반환
+     */
+    private JsonNode findMatchingKey(JsonNode keys, String kid) {
+        for (JsonNode key : keys) {
+            if (key.get("kid").asText().equals(kid))
+                return key;
+        }
+        throw new DomainException(OAuthErrorCode.INVALID_ACCESS_TOKEN);
+    }
+
+    /**
+     * Apple의 JWK(Json Web Key)에서 RSA 공개키 객체 생성
+     * - n: modulus (base64url)
+     * - e: exponent (base64url)
+     */
+    private RSAPublicKey buildPublicKey(JsonNode key) throws Exception {
+        String n = key.get("n").asText();
+        String e = key.get("e").asText();
+
+        // 디코딩하여 BigInteger로 변환
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+
+        // RSA 공개키 생성
+        return (RSAPublicKey) KeyFactory.getInstance("RSA")
+                .generatePublic(new RSAPublicKeySpec(modulus, exponent));
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/AppleTokenVerifier.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.mobble.mobbleserver.account.auth.oauth.dto.response.AppleUserInfoResponse;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.SocialVerifier;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.dto.SocialUserInfo;
-import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.oAuth.OAuthErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ import java.util.Base64;
 public class AppleTokenVerifier implements SocialVerifier {
 
     private final RestClient appleRestClient;
-    private final MemberValidator memberValidator;
 
     @Override
     public SocialUserInfo verify(String idToken) {

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/GoogleTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/GoogleTokenVerifier.java
@@ -25,7 +25,6 @@ public class GoogleTokenVerifier extends AbstractSocialTokenVerifier {
         GoogleUserInfoResponse userInfo = new GoogleUserInfoResponse(attributes);
 
         return new SocialUserInfo(
-                userInfo.getName(),
                 userInfo.getEmail(),
                 userInfo.getProvider(),
                 userInfo.getProviderId()

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/KakaoTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/KakaoTokenVerifier.java
@@ -25,7 +25,6 @@ public class KakaoTokenVerifier extends AbstractSocialTokenVerifier {
         KakaoUserInfoResponse userInfo = new KakaoUserInfoResponse(attributes);
 
         return new SocialUserInfo(
-                userInfo.getName(),
                 userInfo.getEmail(),
                 userInfo.getProvider(),
                 userInfo.getProviderId()

--- a/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/NaverTokenVerifier.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/oauth/verifier/provider/NaverTokenVerifier.java
@@ -25,7 +25,6 @@ public class NaverTokenVerifier extends AbstractSocialTokenVerifier {
         NaverUserInfoResponse userInfo = new NaverUserInfoResponse(attributes);
 
         return new SocialUserInfo(
-                userInfo.getName(),
                 userInfo.getEmail(),
                 userInfo.getProvider(),
                 userInfo.getProviderId()

--- a/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
@@ -30,7 +30,7 @@ public class SocialLoginService {
         SocialVerifier verifier = verifierFactory.getVerifier(dto.socialProvider());
         SocialUserInfo userInfo = verifier.verify(dto.accessToken());
 
-        Member member = memberValidator.validateMemberOrThrow(userInfo.socialProvider(), userInfo.socialId());
+        Member member = memberValidator.findMemberOrThrowIfDeleted(userInfo.socialProvider(), userInfo.socialId());
 
         if (member != null) {
             List<ClubMemberRole> roles = clubMemberRepository.findDistinctRolesByMemberIdAndRoleIn(member.getId(), List.of(ClubMemberRole.LEADER, ClubMemberRole.MANAGER));

--- a/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
@@ -44,7 +44,6 @@ public class SocialLoginService {
         if (userInfo.email() == null) throw new DomainException(OAuthErrorCode.NO_USER_INFO); // for Apple Login
 
         String signupToken = tokenProvider.createSignupToken(
-                userInfo.name(),
                 userInfo.email(),
                 userInfo.socialProvider(),
                 userInfo.socialId());

--- a/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
@@ -43,10 +43,7 @@ public class SocialLoginService {
 
         if (userInfo.email() == null) throw new DomainException(OAuthErrorCode.NO_USER_INFO); // for Apple Login
 
-        String signupToken = tokenProvider.createSignupToken(
-                userInfo.email(),
-                userInfo.socialProvider(),
-                userInfo.socialId());
+        String signupToken = tokenProvider.createSignupToken(userInfo.email(), userInfo.socialProvider(), userInfo.socialId());
 
         return SocialLoginResponseDto.newMember(signupToken);
     }

--- a/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/service/SocialLoginService.java
@@ -10,6 +10,8 @@ import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
 import com.mobble.mobbleserver.domain.clubMember.repository.ClubMemberRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.oAuth.OAuthErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +41,13 @@ public class SocialLoginService {
             return SocialLoginResponseDto.existMember(jwtToken);
         }
 
-        String signupToken = tokenProvider.createSignupToken(userInfo.name(), userInfo.email(), userInfo.socialProvider(), userInfo.socialId());
+        if (userInfo.email() == null) throw new DomainException(OAuthErrorCode.NO_USER_INFO); // for Apple Login
+
+        String signupToken = tokenProvider.createSignupToken(
+                userInfo.name(),
+                userInfo.email(),
+                userInfo.socialProvider(),
+                userInfo.socialId());
 
         return SocialLoginResponseDto.newMember(signupToken);
     }

--- a/src/main/java/com/mobble/mobbleserver/account/jwt/TokenProvider.java
+++ b/src/main/java/com/mobble/mobbleserver/account/jwt/TokenProvider.java
@@ -52,12 +52,11 @@ public class TokenProvider {
     }
 
     // 회원가입용 Signup Token 생성
-    public String createSignupToken(String name, String email, SocialProvider socialProvider, String socialId) {
+    public String createSignupToken(String email, SocialProvider socialProvider, String socialId) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + 1000L * 60 * 10); // Valid Time: 10 minute
 
         Map<String, Object> claims = new HashMap<>();
-        claims.put("name", name);
         claims.put("email", email);
         claims.put("socialProvider", String.valueOf(socialProvider));
         claims.put("socialId", socialId);
@@ -100,12 +99,11 @@ public class TokenProvider {
     public SocialUserInfo getSignupTokenInfo(String signupToken) {
         Claims claims = parse(signupToken);
 
-        String name = (String) claims.get("name");
         String email = (String) claims.get("email");
         SocialProvider socialProvider = SocialProvider.valueOf((String) claims.get("socialProvider"));
         String socialId = (String) claims.get("socialId");
 
-        return new SocialUserInfo(name, email, socialProvider, socialId);
+        return new SocialUserInfo(email, socialProvider, socialId);
     }
 
     /* =======================

--- a/src/main/java/com/mobble/mobbleserver/config/RestClientConfig.java
+++ b/src/main/java/com/mobble/mobbleserver/config/RestClientConfig.java
@@ -32,4 +32,12 @@ public class RestClientConfig {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
+
+    @Bean
+    public RestClient appleRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://appleid.apple.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
 }

--- a/src/main/java/com/mobble/mobbleserver/config/SecurityConfig.java
+++ b/src/main/java/com/mobble/mobbleserver/config/SecurityConfig.java
@@ -42,10 +42,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",
-                                "/social-login.html",
-                                "/signup/details-info.html",
-                                "/login-success.html"
+                                "/api/auth/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/mobble/mobbleserver/config/SecurityConfig.java
+++ b/src/main/java/com/mobble/mobbleserver/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**"
+                                "/api/auth/**",
+                                "/apple/callback"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -32,7 +32,7 @@ public class Member extends BaseEntity {
     @Column(name = "gender")
     private Gender gender;
 
-    @Column(name = "email", unique = true)
+    @Column(name = "email")
     private String email;
 
     @Column(name = "phone")

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -21,7 +21,7 @@ public class MemberValidator {
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public Member validateMemberOrThrow(SocialProvider socialProvider, String socialId) {
+    public Member findMemberOrThrowIfDeleted(SocialProvider socialProvider, String socialId) {
         return memberRepository.findBySocialProviderAndSocialId(socialProvider, socialId)
                 .map(member -> {
                     if (member.isDeleted()) {

--- a/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/member/MemberValidationErrorCode.java
+++ b/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/member/MemberValidationErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum MemberValidationErrorCode implements ErrorCode {
-    NAME_NOT_BLANK("이름을 입력해주세요.", HttpStatus.BAD_REQUEST),
+    REQUIRED_NAME("이름을 입력해주세요.", HttpStatus.BAD_REQUEST),
     NAME_TOO_LONG("이름은 최대 10자까지 입력 가능합니다..", HttpStatus.BAD_REQUEST),
     AGE_TOO_LOW("나이는 1세 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
     AGE_TOO_HIGH("나이는 100세 이하로 입력해주세요.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📄 APPLE 소셜로그인 기능 구현
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #136 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- AppleCallbackController: 브라우저 Apple 로그인 완료 후 id_token 수신하는 테스트용 콜백 엔드포인트 (Ngrok 활용 테스트용)
- AppleTokenVerifier: id_token을 디코딩하고, Apple 사용자의 socialId(sub), email 정보를 추출
- AppleUserInfoResponse: Apple id_token을 파싱한 후 사용자 정보(sub, email)를 담는 내부 DTO
- AppleCallbackController 에서 받아온 id_token 타 소셜로그인과 동일하게 id_token, SocialProvider 로 로그인 및 회원가입
- Signup Token 생성, 활용 시 name 필드 제거
- Member 엔티티 email 유니크 설정 제거

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 👀 중점적으로 봐줬으면 하는 부분
<!-- 리뷰어가 집중해서 봐야 할 부분이 있다면 -->
- Apple 로그인 흐름이 기존 소셜 로그인과 통일성 있게 구현되었는지

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- Signup Token에서 name 속성 제거하여 회원가입 추가정보 입력에서 입력 받음
    - 본인인증 API 도입 후 이름, 전화번호는 인증된 정보로 전달 받을 예정
- AppleCallbackController는 개발 환경에서 id_token 전달 시 사용, 클라이언트 구현 시 제거 예정