### PR TITLE
Test/base like entity

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
@@ -7,7 +7,6 @@ import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import com.mobble.mobbleserver.support.fixture.article.ArticleTestFixture;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -18,37 +17,33 @@ public class ArticleLikeTest {
     private final Member mockMember = MemberTestFixture.createDefaultMember();
     private final Article mockArticle = ArticleTestFixture.createDefaultArticle();
 
-    @Nested
-    @DisplayName("ArticleLike 생성 테스트")
-    class CreateArticleLike {
 
-        @Test
-        @DisplayName("ArticleLike 생성 성공")
-        void success_when_create_article_like() {
-            // when
-            ArticleLike like = ArticleLike.createArticleLike(mockArticle, mockMember);
+    @Test
+    @DisplayName("ArticleLike 생성 성공")
+    void success_when_create_article_like() {
+        // when
+        ArticleLike like = ArticleLike.createArticleLike(mockArticle, mockMember);
 
-            //then
-            assertThat(like.getArticle()).isEqualTo(mockArticle);
-            assertThat(like.getMember()).isEqualTo(mockMember);
-        }
+        //then
+        assertThat(like.getArticle()).isEqualTo(mockArticle);
+        assertThat(like.getMember()).isEqualTo(mockMember);
+    }
 
-        @Test
-        @DisplayName("article 이 null 인 경우 예외 발생")
-        void fails_when_article_is_null() {
-            // when & then
-            assertThatThrownBy(() -> ArticleLike.createArticleLike(null, mockMember))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
-        }
+    @Test
+    @DisplayName("article 이 null 인 경우 예외 발생")
+    void fails_when_article_is_null() {
+        // when & then
+        assertThatThrownBy(() -> ArticleLike.createArticleLike(null, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
+    }
 
-        @Test
-        @DisplayName("member 가 null 인 경우 예외 발생")
-        void fails_when_member_is_null() {
-            // when & then
-            assertThatThrownBy(() -> ArticleLike.createArticleLike(mockArticle, null))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
-        }
+    @Test
+    @DisplayName("member 가 null 인 경우 예외 발생")
+    void fails_when_member_is_null() {
+        // when & then
+        assertThatThrownBy(() -> ArticleLike.createArticleLike(mockArticle, null))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class ArticleLikeTest {
+class ArticleLikeTest {
 
     private final Member mockMember = MemberTestFixture.createDefaultMember();
     private final Article mockArticle = ArticleTestFixture.createDefaultArticle();

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/entity/ArticleLikeTest.java
@@ -1,0 +1,54 @@
+package com.mobble.mobbleserver.domain.like.articleLike.entity;
+
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
+import com.mobble.mobbleserver.support.fixture.article.ArticleTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class ArticleLikeTest {
+
+    private final Member mockMember = MemberTestFixture.createDefaultMember();
+    private final Article mockArticle = ArticleTestFixture.createDefaultArticle();
+
+    @Nested
+    @DisplayName("ArticleLike 생성 테스트")
+    class CreateArticleLike {
+
+        @Test
+        @DisplayName("ArticleLike 생성 성공")
+        void success_when_create_article_like() {
+            // when
+            ArticleLike like = ArticleLike.createArticleLike(mockArticle, mockMember);
+
+            //then
+            assertThat(like.getArticle()).isEqualTo(mockArticle);
+            assertThat(like.getMember()).isEqualTo(mockMember);
+        }
+
+        @Test
+        @DisplayName("article 이 null 인 경우 예외 발생")
+        void fails_when_article_is_null() {
+            // when & then
+            assertThatThrownBy(() -> ArticleLike.createArticleLike(null, mockMember))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("member 가 null 인 경우 예외 발생")
+        void fails_when_member_is_null() {
+            // when & then
+            assertThatThrownBy(() -> ArticleLike.createArticleLike(mockArticle, null))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
@@ -4,6 +4,7 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeTestFixture.TestLike;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,32 +13,22 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class BaseLikeTest {
 
-    // 테스트용 구현체
-    static class TestLike extends BaseLike {
-        public static TestLike create(Member member) {
-            TestLike like = new TestLike();
-            like.assignMember(member);
-            return like;
-        }
-    }
-
     private final Member mockMember = MemberTestFixture.createDefaultMember();
+    private final TestLike mockTestLike = LikeTestFixture.create(mockMember);
+
 
     @Test
     @DisplayName("Member 주입 성공")
     void assignMember_success() {
-        // when
-        TestLike testLike = TestLike.create(mockMember);
-
         // then
-        assertThat(testLike.getMember()).isEqualTo(mockMember);
+        assertThat(mockTestLike.getMember()).isEqualTo(mockMember);
     }
 
     @Test
     @DisplayName("Member 가 null 인 경우 예외 발생")
     void fails_when_assignMember_member_is_null() {
         //when & then
-        assertThatThrownBy(() -> TestLike.create(null))
+        assertThatThrownBy(() -> LikeTestFixture.create(null))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
     }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
@@ -5,7 +5,6 @@ import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -24,27 +23,22 @@ class BaseLikeTest {
 
     private final Member mockMember = MemberTestFixture.createDefaultMember();
 
-    @Nested
-    @DisplayName("Member 주입 테스트")
-    class AssignMemberTest {
+    @Test
+    @DisplayName("Member 주입 성공")
+    void assignMember_success() {
+        // when
+        TestLike testLike = TestLike.create(mockMember);
 
-        @Test
-        @DisplayName("Member 주입 성공")
-        void assignMember_success() {
-            // when
-            TestLike testLike = TestLike.create(mockMember);
+        // then
+        assertThat(testLike.getMember()).isEqualTo(mockMember);
+    }
 
-            // then
-            assertThat(testLike.getMember()).isEqualTo(mockMember);
-        }
-
-        @Test
-        @DisplayName("Member가 nulldls 인 경우 예외 발생")
-        void fails_when_assignMember_member_is_null() {
-            //when & then
-            assertThatThrownBy(() -> TestLike.create(null))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
-        }
+    @Test
+    @DisplayName("Member가 nulldls 인 경우 예외 발생")
+    void fails_when_assignMember_member_is_null() {
+        //when & then
+        assertThatThrownBy(() -> TestLike.create(null))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
@@ -1,0 +1,50 @@
+package com.mobble.mobbleserver.domain.like.baseLike.entity;
+
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class BaseLikeTest {
+
+    // 테스트용 구현체
+    static class TestLike extends BaseLike {
+        public static TestLike create(Member member) {
+            TestLike like = new TestLike();
+            like.assignMember(member);
+            return like;
+        }
+    }
+
+    private final Member mockMember = MemberTestFixture.createDefaultMember();
+
+    @Nested
+    @DisplayName("Member 주입 테스트")
+    class AssignMemberTest {
+
+        @Test
+        @DisplayName("Member 주입 성공")
+        void assignMember_success() {
+            // when
+            TestLike testLike = TestLike.create(mockMember);
+
+            // then
+            assertThat(testLike.getMember()).isEqualTo(mockMember);
+        }
+
+        @Test
+        @DisplayName("Member가 nulldls 인 경우 예외 발생")
+        void fails_when_assignMember_member_is_null() {
+            //when & then
+            assertThatThrownBy(() -> TestLike.create(null))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
@@ -4,7 +4,6 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
-import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeTestFixture.TestLike;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 class BaseLikeTest {
 
     private final Member mockMember = MemberTestFixture.createDefaultMember();
-    private final TestLike mockTestLike = LikeTestFixture.create(mockMember);
+    private final LikeTestFixture mockTestLike = LikeTestFixture.create(mockMember);
 
 
     @Test

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/BaseLikeTest.java
@@ -34,7 +34,7 @@ class BaseLikeTest {
     }
 
     @Test
-    @DisplayName("Member가 nulldls 인 경우 예외 발생")
+    @DisplayName("Member 가 null 인 경우 예외 발생")
     void fails_when_assignMember_member_is_null() {
         //when & then
         assertThatThrownBy(() -> TestLike.create(null))

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/LikeTestFixture.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/LikeTestFixture.java
@@ -2,14 +2,11 @@ package com.mobble.mobbleserver.domain.like.baseLike.entity;
 
 import com.mobble.mobbleserver.domain.member.entity.Member;
 
-public class LikeTestFixture {
+public class LikeTestFixture extends BaseLike{
 
-    public static TestLike create(Member member) {
-        TestLike like = new TestLike();
+    public static LikeTestFixture create(Member member) {
+        LikeTestFixture like = new LikeTestFixture();
         like.assignMember(member);
         return like;
-    }
-
-    public static class TestLike extends BaseLike {
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/LikeTestFixture.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/entity/LikeTestFixture.java
@@ -1,0 +1,15 @@
+package com.mobble.mobbleserver.domain.like.baseLike.entity;
+
+import com.mobble.mobbleserver.domain.member.entity.Member;
+
+public class LikeTestFixture {
+
+    public static TestLike create(Member member) {
+        TestLike like = new TestLike();
+        like.assignMember(member);
+        return like;
+    }
+
+    public static class TestLike extends BaseLike {
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLikeTest.java
@@ -9,50 +9,43 @@ import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
 import com.mobble.mobbleserver.support.fixture.clubCategory.ClubCategoryTestFixture;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class ClubLikeTest {
+class ClubLikeTest {
 
     private final Member mockMember = MemberTestFixture.createDefaultMember();
     private final ClubCategory mockClubCategory = ClubCategoryTestFixture.createDefaultCategory();
     private final Club mockClub = ClubTestFixture.createDefaultClub(mockClubCategory);
 
-    @Nested
-    @DisplayName("ClubLike 생성 테스트")
-    class CreateArticleLike {
+    @Test
+    @DisplayName("ClubLike 생성 성공")
+    void success_when_create_article_like() {
+        // when
+        ClubLike like = ClubLike.createClubLike(mockClub, mockMember);
 
-        @Test
-        @DisplayName("ClubLike 생성 성공")
-        void success_when_create_article_like() {
-            // when
-            ClubLike like = ClubLike.createClubLike(mockClub, mockMember);
+        //then
+        assertThat(like.getClub()).isEqualTo(mockClub);
+        assertThat(like.getMember()).isEqualTo(mockMember);
+    }
 
-            //then
-            assertThat(like.getClub()).isEqualTo(mockClub);
-            assertThat(like.getMember()).isEqualTo(mockMember);
-        }
+    @Test
+    @DisplayName("club 이 null 인 경우 예외 발생")
+    void fails_when_article_is_null() {
+        // when & then
+        assertThatThrownBy(() -> ClubLike.createClubLike(null, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.CLUB_REQUIRED.message());
+    }
 
-        @Test
-        @DisplayName("club 이 null 인 경우 예외 발생")
-        void fails_when_article_is_null() {
-            // when & then
-            assertThatThrownBy(() -> ClubLike.createClubLike(null, mockMember))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.CLUB_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("member 가 null 인 경우 예외 발생")
-        void fails_when_member_is_null() {
-            // when & then
-            assertThatThrownBy(() -> ClubLike.createClubLike(mockClub, null))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
-        }
+    @Test
+    @DisplayName("member 가 null 인 경우 예외 발생")
+    void fails_when_member_is_null() {
+        // when & then
+        assertThatThrownBy(() -> ClubLike.createClubLike(mockClub, null))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
     }
 }
-

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/entity/ClubLikeTest.java
@@ -1,0 +1,58 @@
+package com.mobble.mobbleserver.domain.like.clubLike.entity;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.clubCategory.ClubCategoryTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class ClubLikeTest {
+
+    private final Member mockMember = MemberTestFixture.createDefaultMember();
+    private final ClubCategory mockClubCategory = ClubCategoryTestFixture.createDefaultCategory();
+    private final Club mockClub = ClubTestFixture.createDefaultClub(mockClubCategory);
+
+    @Nested
+    @DisplayName("ClubLike 생성 테스트")
+    class CreateArticleLike {
+
+        @Test
+        @DisplayName("ClubLike 생성 성공")
+        void success_when_create_article_like() {
+            // when
+            ClubLike like = ClubLike.createClubLike(mockClub, mockMember);
+
+            //then
+            assertThat(like.getClub()).isEqualTo(mockClub);
+            assertThat(like.getMember()).isEqualTo(mockMember);
+        }
+
+        @Test
+        @DisplayName("club 이 null 인 경우 예외 발생")
+        void fails_when_article_is_null() {
+            // when & then
+            assertThatThrownBy(() -> ClubLike.createClubLike(null, mockMember))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.CLUB_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("member 가 null 인 경우 예외 발생")
+        void fails_when_member_is_null() {
+            // when & then
+            assertThatThrownBy(() -> ClubLike.createClubLike(mockClub, null))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
+        }
+    }
+}
+

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/entity/CommentLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/entity/CommentLikeTest.java
@@ -1,0 +1,54 @@
+package com.mobble.mobbleserver.domain.like.commentLike.entity;
+
+import com.mobble.mobbleserver.domain.comment.entity.Comment;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
+import com.mobble.mobbleserver.support.fixture.comment.CommentTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class CommentLikeTest {
+
+    private final Member mockMember = MemberTestFixture.createDefaultMember();
+    private final Comment mockComment = CommentTestFixture.createDefaultRootComment();
+
+    @Nested
+    @DisplayName("CommentLike 생성 테스트")
+    class CreateCommentLike {
+
+        @Test
+        @DisplayName("CommentLike 생성 성공")
+        void success_when_create_comment_like() {
+            // when
+            CommentLike like = CommentLike.createCommentLike(mockComment, mockMember);
+
+            // then
+            assertThat(like.getComment()).isEqualTo(mockComment);
+            assertThat(like.getMember()).isEqualTo(mockMember);
+        }
+
+        @Test
+        @DisplayName("comment 가 null 인 경우 예외 발생")
+        void fails_when_comment_is_null() {
+            // when & then
+            assertThatThrownBy(() -> CommentLike.createCommentLike(null, mockMember))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("member 가 null 인 경우 예외 발생")
+        void fails_when_member_is_null() {
+            // when & then
+            assertThatThrownBy(() -> CommentLike.createCommentLike(mockComment, null))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/entity/CommentLikeTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/entity/CommentLikeTest.java
@@ -13,42 +13,37 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class CommentLikeTest {
+class CommentLikeTest {
 
     private final Member mockMember = MemberTestFixture.createDefaultMember();
     private final Comment mockComment = CommentTestFixture.createDefaultRootComment();
 
-    @Nested
-    @DisplayName("CommentLike 생성 테스트")
-    class CreateCommentLike {
+    @Test
+    @DisplayName("CommentLike 생성 성공")
+    void success_when_create_comment_like() {
+        // when
+        CommentLike like = CommentLike.createCommentLike(mockComment, mockMember);
 
-        @Test
-        @DisplayName("CommentLike 생성 성공")
-        void success_when_create_comment_like() {
-            // when
-            CommentLike like = CommentLike.createCommentLike(mockComment, mockMember);
+        // then
+        assertThat(like.getComment()).isEqualTo(mockComment);
+        assertThat(like.getMember()).isEqualTo(mockMember);
+    }
 
-            // then
-            assertThat(like.getComment()).isEqualTo(mockComment);
-            assertThat(like.getMember()).isEqualTo(mockMember);
-        }
+    @Test
+    @DisplayName("comment 가 null 인 경우 예외 발생")
+    void fails_when_comment_is_null() {
+        // when & then
+        assertThatThrownBy(() -> CommentLike.createCommentLike(null, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
+    }
 
-        @Test
-        @DisplayName("comment 가 null 인 경우 예외 발생")
-        void fails_when_comment_is_null() {
-            // when & then
-            assertThatThrownBy(() -> CommentLike.createCommentLike(null, mockMember))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
-        }
-
-        @Test
-        @DisplayName("member 가 null 인 경우 예외 발생")
-        void fails_when_member_is_null() {
-            // when & then
-            assertThatThrownBy(() -> CommentLike.createCommentLike(mockComment, null))
-                    .isInstanceOf(DomainException.class)
-                    .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
-        }
+    @Test
+    @DisplayName("member 가 null 인 경우 예외 발생")
+    void fails_when_member_is_null() {
+        // when & then
+        assertThatThrownBy(() -> CommentLike.createCommentLike(mockComment, null))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.MEMBER_REQUIRED.message());
     }
 }


### PR DESCRIPTION
## 📄 Test: Like Entity 단위 테스트
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #148 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- BaseLikeTest: 테스트용 구현 클래스 정의, assignMember() 정상 및 예외 케이스 검증
- 도메인별 LikeTest: 생성 성공 및 domain(Article, Club, Comment) / member null 예외 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인
