### PR TITLE
Test/like service

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -6,6 +6,8 @@ import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
 import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.article.ArticleErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,5 +72,20 @@ class ArticleLikeQueryServiceTest {
         assertThat(response.likedMembers()).hasSize(2);
         verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
         verify(articleLikeRepository).findAllByArticleId(ARTICLE_ID);
+    }
+
+    @DisplayName("조회할 게시글이 존재하지 않으면 예외 발생")
+    @Test
+    void fail_when_article_not_found() {
+        // given
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willThrow(new DomainException(ArticleErrorCode.NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> articleLikeQueryService.getLikedMemberList(ARTICLE_ID))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ArticleErrorCode.NOT_FOUND.message());
+
+        verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -88,4 +88,25 @@ class ArticleLikeQueryServiceTest {
 
         verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
     }
+
+    @DisplayName("좋아요한 멤버가 없으면 빈 리스트 반환")
+    @Test
+    void success_when_no_liked_members() {
+        // given
+        given(mockArticle.getId()).willReturn(ARTICLE_ID);
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willReturn(mockArticle);
+        given(articleLikeRepository.findAllByArticleId(ARTICLE_ID))
+                .willReturn(List.of());
+
+        // when
+        LikeMemberListResponseDto response = articleLikeQueryService.getLikedMemberList(ARTICLE_ID);
+
+        // then
+        assertThat(response.targetId()).isEqualTo(ARTICLE_ID);
+        assertThat(response.likedMembers()).isEmpty();
+
+        verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
+        verify(articleLikeRepository).findAllByArticleId(ARTICLE_ID);
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -44,8 +44,8 @@ class ArticleLikeQueryServiceTest {
         mockArticle = mock(Article.class);
     }
 
-    @DisplayName("게시글 좋아요 한 멤버 목록 조회 성공")
     @Test
+    @DisplayName("게시글 좋아요 한 멤버 목록 조회 성공")
     void success_get_liked_member_list() {
         // given
         ArticleLike mockLike1 = mock(ArticleLike.class);
@@ -70,8 +70,8 @@ class ArticleLikeQueryServiceTest {
         verify(articleLikeRepository).findAllByArticleId(ARTICLE_ID);
     }
 
-    @DisplayName("조회할 게시글이 존재하지 않으면 예외 발생")
     @Test
+    @DisplayName("조회할 게시글이 존재하지 않으면 예외 발생")
     void fail_when_article_not_found() {
         // given
         given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
@@ -85,8 +85,8 @@ class ArticleLikeQueryServiceTest {
         verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
     }
 
-    @DisplayName("좋아요한 멤버가 없으면 빈 리스트 반환")
     @Test
+    @DisplayName("좋아요한 멤버가 없으면 빈 리스트 반환")
     void success_when_no_liked_members() {
         // given
         given(mockArticle.getId()).willReturn(ARTICLE_ID);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -62,7 +62,6 @@ class ArticleLikeQueryServiceTest {
         given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
         given(articleLikeRepository.findAllByArticleId(ARTICLE_ID)).willReturn(List.of(mockLike1, mockLike2));
 
-
         // when
         LikeMemberListResponseDto response = articleLikeQueryService.getLikedMemberList(ARTICLE_ID);
 

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -74,8 +74,7 @@ class ArticleLikeQueryServiceTest {
     @DisplayName("조회할 게시글이 존재하지 않으면 예외 발생")
     void fail_when_article_not_found() {
         // given
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willThrow(new DomainException(ArticleErrorCode.NOT_FOUND));
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willThrow(new DomainException(ArticleErrorCode.NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> articleLikeQueryService.getLikedMemberList(ARTICLE_ID))
@@ -90,10 +89,8 @@ class ArticleLikeQueryServiceTest {
     void success_when_no_liked_members() {
         // given
         given(mockArticle.getId()).willReturn(ARTICLE_ID);
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willReturn(mockArticle);
-        given(articleLikeRepository.findAllByArticleId(ARTICLE_ID))
-                .willReturn(List.of());
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+        given(articleLikeRepository.findAllByArticleId(ARTICLE_ID)).willReturn(List.of());
 
         // when
         LikeMemberListResponseDto response = articleLikeQueryService.getLikedMemberList(ARTICLE_ID);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -1,0 +1,75 @@
+package com.mobble.mobbleserver.domain.like.articleLike.service;
+
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.article.validator.ArticleValidator;
+import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
+import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
+import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleLikeQueryServiceTest {
+
+    @Mock
+    private ArticleValidator articleValidator;
+
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
+
+    @InjectMocks
+    ArticleLikeQueryService articleLikeQueryService;
+
+    private static final Long ARTICLE_ID = 1L;
+
+    private Member mockMember;
+    private Article mockArticle;
+    private ArticleLike mockArticleLike;
+
+    @BeforeEach
+    void setUp() {
+        mockMember = mock(Member.class);
+        mockArticle = mock(Article.class);
+        mockArticleLike = mock(ArticleLike.class);
+    }
+
+    @DisplayName("게시글 좋아요 한 멤버 목록 조회 성공")
+    @Test
+    void success_get_liked_member_list() {
+        // given
+        ArticleLike mockLike1 = mock(ArticleLike.class);
+        ArticleLike mockLike2 = mock(ArticleLike.class);
+        Member mockMember1 = mock(Member.class);
+        Member mockMember2 = mock(Member.class);
+
+        given(mockLike1.getMember()).willReturn(mockMember1);
+        given(mockLike2.getMember()).willReturn(mockMember2);
+
+        given(mockArticle.getId()).willReturn(ARTICLE_ID);
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+        given(articleLikeRepository.findAllByArticleId(ARTICLE_ID)).willReturn(List.of(mockLike1, mockLike2));
+
+
+        // when
+        LikeMemberListResponseDto response = articleLikeQueryService.getLikedMemberList(ARTICLE_ID);
+
+        // then
+        assertThat(response.targetId()).isEqualTo(ARTICLE_ID);
+        assertThat(response.likedMembers()).hasSize(2);
+        verify(articleValidator).findArticleByArticleIdOrThrow(ARTICLE_ID);
+        verify(articleLikeRepository).findAllByArticleId(ARTICLE_ID);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeQueryServiceTest.java
@@ -37,15 +37,11 @@ class ArticleLikeQueryServiceTest {
 
     private static final Long ARTICLE_ID = 1L;
 
-    private Member mockMember;
     private Article mockArticle;
-    private ArticleLike mockArticleLike;
 
     @BeforeEach
     void setUp() {
-        mockMember = mock(Member.class);
         mockArticle = mock(Article.class);
-        mockArticleLike = mock(ArticleLike.class);
     }
 
     @DisplayName("게시글 좋아요 한 멤버 목록 조회 성공")

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -8,6 +8,8 @@ import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
 import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -100,5 +103,18 @@ class ArticleLikeServiceTest {
         // then
         verify(articleLikeRepository).delete(mockArticleLike);
         assertThat(result).isFalse();
+    }
+
+    @DisplayName("좋아요할 게시글이 없으면 예외 발생")
+    @Test
+    void fail_when_article_not_found() {
+        // given
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willThrow(new DomainException(LikeErrorCode.ARTICLE_REQUIRED));
+
+        //when & then
+        assertThatThrownBy(() -> articleLikeService.toggleLike(ARTICLE_ID, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -60,8 +60,8 @@ class ArticleLikeServiceTest {
         mockArticleLike = mock(ArticleLike.class);
     }
 
-    @DisplayName("게시글 좋아요가 없으면 생성")
     @Test
+    @DisplayName("게시글 좋아요가 없으면 생성")
     void success_when_not_liked() {
         // given
         Long clubId = 10L;
@@ -83,8 +83,8 @@ class ArticleLikeServiceTest {
         verify(articleLikeRepository).save(any(ArticleLike.class));
     }
 
-    @DisplayName("게시글 좋아요가 있으면 삭제")
     @Test
+    @DisplayName("게시글 좋아요가 있으면 삭제")
     void success_when_has_liked() {
         // given
         given(mockArticle.getId()).willReturn(ARTICLE_ID);
@@ -102,8 +102,8 @@ class ArticleLikeServiceTest {
         verify(articleLikeRepository, never()).save(any());
     }
 
-    @DisplayName("좋아요할 게시글이 없으면 예외 발생")
     @Test
+    @DisplayName("좋아요할 게시글이 없으면 예외 발생")
     void fail_when_article_not_found() {
         // given
         given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willThrow(new DomainException(LikeErrorCode.ARTICLE_REQUIRED));
@@ -114,8 +114,8 @@ class ArticleLikeServiceTest {
                 .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
     }
 
-    @DisplayName("클럽 멤버가 아니면 예외 발생")
     @Test
+    @DisplayName("클럽 멤버가 아니면 예외 발생")
     void fail_when_not_club_member() {
         // given
         Long clubId = 10L;

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -9,6 +9,7 @@ import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
 import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberValidationErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -116,5 +117,29 @@ class ArticleLikeServiceTest {
         assertThatThrownBy(() -> articleLikeService.toggleLike(ARTICLE_ID, mockMember))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(LikeErrorCode.ARTICLE_REQUIRED.message());
+    }
+
+    @DisplayName("클럽 멤버가 아니면 예외 발생")
+    @Test
+    void fail_when_not_club_member() {
+        // given
+        Long clubId = 10L;
+
+        given(mockArticle.getId()).willReturn(ARTICLE_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+        given(mockArticle.getClub()).willReturn(mockClub);
+        given(mockClub.getId()).willReturn(clubId);
+
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
+                .willReturn(Optional.empty());
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID))
+                .willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> articleLikeService.toggleLike(ARTICLE_ID, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -71,12 +71,9 @@ class ArticleLikeServiceTest {
         given(mockArticle.getClub()).willReturn(mockClub);
         given(mockClub.getId()).willReturn(clubId);
 
-        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID))
-                .willReturn(mockClubMember);
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willReturn(mockArticle);
-        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
-                .willReturn(Optional.empty());
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willReturn(mockClubMember);
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID)).willReturn(Optional.empty());
 
         // when
         boolean result = articleLikeService.toggleLike(ARTICLE_ID, mockMember).isLiked();
@@ -93,10 +90,8 @@ class ArticleLikeServiceTest {
         given(mockArticle.getId()).willReturn(ARTICLE_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
 
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willReturn(mockArticle);
-        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
-                .willReturn(Optional.of(mockArticleLike));
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID)).willReturn(Optional.of(mockArticleLike));
 
         // when
         boolean result = articleLikeService.toggleLike(ARTICLE_ID, mockMember).isLiked();
@@ -110,8 +105,7 @@ class ArticleLikeServiceTest {
     @Test
     void fail_when_article_not_found() {
         // given
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willThrow(new DomainException(LikeErrorCode.ARTICLE_REQUIRED));
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willThrow(new DomainException(LikeErrorCode.ARTICLE_REQUIRED));
 
         //when & then
         assertThatThrownBy(() -> articleLikeService.toggleLike(ARTICLE_ID, mockMember))
@@ -130,12 +124,9 @@ class ArticleLikeServiceTest {
         given(mockArticle.getClub()).willReturn(mockClub);
         given(mockClub.getId()).willReturn(clubId);
 
-        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
-                .willReturn(mockArticle);
-        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
-                .willReturn(Optional.empty());
-        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID))
-                .willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID)).willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID)).willReturn(Optional.empty());
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> articleLikeService.toggleLike(ARTICLE_ID, mockMember))

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -18,10 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static com.mobble.mobbleserver.domain.member.entity.QMember.member;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 
@@ -83,3 +81,24 @@ class ArticleLikeServiceTest {
         assertThat(result).isTrue();
         verify(articleLikeRepository).save(any(ArticleLike.class));
     }
+
+    @DisplayName("좋아요가 있으면 삭제")
+    @Test
+    void success_when_has_liked() {
+        // given
+        given(mockArticle.getId()).willReturn(ARTICLE_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
+                .willReturn(Optional.of(mockArticleLike));
+
+        // when
+        boolean result = articleLikeService.toggleLike(ARTICLE_ID, mockMember).isLiked();
+
+        // then
+        verify(articleLikeRepository).delete(mockArticleLike);
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -60,7 +60,7 @@ class ArticleLikeServiceTest {
         mockArticleLike = mock(ArticleLike.class);
     }
 
-    @DisplayName("좋아요가 없으면 생성")
+    @DisplayName("게시글 좋아요가 없으면 생성")
     @Test
     void success_when_not_liked() {
         // given
@@ -83,7 +83,7 @@ class ArticleLikeServiceTest {
         verify(articleLikeRepository).save(any(ArticleLike.class));
     }
 
-    @DisplayName("좋아요가 있으면 삭제")
+    @DisplayName("게시글 좋아요가 있으면 삭제")
     @Test
     void success_when_has_liked() {
         // given

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -97,8 +97,9 @@ class ArticleLikeServiceTest {
         boolean result = articleLikeService.toggleLike(ARTICLE_ID, mockMember).isLiked();
 
         // then
-        verify(articleLikeRepository).delete(mockArticleLike);
         assertThat(result).isFalse();
+        verify(articleLikeRepository).delete(mockArticleLike);
+        verify(articleLikeRepository, never()).save(any());
     }
 
     @DisplayName("좋아요할 게시글이 없으면 예외 발생")

--- a/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/articleLike/service/ArticleLikeServiceTest.java
@@ -1,0 +1,85 @@
+package com.mobble.mobbleserver.domain.like.articleLike.service;
+
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.article.validator.ArticleValidator;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
+import com.mobble.mobbleserver.domain.like.articleLike.entity.ArticleLike;
+import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.mobble.mobbleserver.domain.member.entity.QMember.member;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class ArticleLikeServiceTest {
+
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
+
+    @Mock
+    private ArticleValidator articleValidator;
+
+    @Mock
+    private ClubMemberValidator clubMemberValidator;
+
+    @InjectMocks
+    private ArticleLikeService articleLikeService;
+
+    private static final Long ARTICLE_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+
+    private Article mockArticle;
+    private Member mockMember;
+    private Club mockClub;
+    private ClubMember mockClubMember;
+    private ArticleLike mockArticleLike;
+
+    @BeforeEach
+    void setUp() {
+        mockArticle = mock(Article.class);
+        mockMember = mock(Member.class);
+        mockClub = mock(Club.class);
+        mockClubMember = mock(ClubMember.class);
+        mockArticleLike = mock(ArticleLike.class);
+    }
+
+    @DisplayName("좋아요가 없으면 생성")
+    @Test
+    void success_when_not_liked() {
+        // given
+        Long clubId = 10L;
+
+        given(mockArticle.getId()).willReturn(ARTICLE_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+        given(mockArticle.getClub()).willReturn(mockClub);
+        given(mockClub.getId()).willReturn(clubId);
+
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID))
+                .willReturn(mockClubMember);
+        given(articleValidator.findArticleByArticleIdOrThrow(ARTICLE_ID))
+                .willReturn(mockArticle);
+        given(articleLikeRepository.findLikedByArticleIdAndMemberId(ARTICLE_ID, MEMBER_ID))
+                .willReturn(Optional.empty());
+
+        // when
+        boolean result = articleLikeService.toggleLike(ARTICLE_ID, mockMember).isLiked();
+
+        // then
+        assertThat(result).isTrue();
+        verify(articleLikeRepository).save(any(ArticleLike.class));
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -6,9 +6,11 @@ import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleRespo
 import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
-import org.assertj.core.api.Assertions;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,13 +55,12 @@ class LikeDispatcherServiceTest {
     class ToggleLikeTest {
 
         @Test
-        @DisplayName("성공 - ARTICLE 타입일 때")
+        @DisplayName("성공 - ARTICLE 만 지원")
         void success_toggleLike_article() {
             // given
             given(mockMemberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
             given(mockArticleLikeService.getType()).willReturn(LikeType.ARTICLE);
-            given(mockArticleLikeService.toggleLike(TARGET_ID, mockMember))
-                    .willReturn(new LikeToggleResponseDto(TARGET_ID, true));
+            given(mockArticleLikeService.toggleLike(TARGET_ID, mockMember)).willReturn(new LikeToggleResponseDto(TARGET_ID, true));
 
             // when
             LikeToggleResponseDto result = likeDispatcherService.toggleLike(LikeType.ARTICLE, TARGET_ID, MEMBER_ID);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -2,6 +2,7 @@ package com.mobble.mobbleserver.domain.like.baseLike.service;
 
 import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeQueryService;
 import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeService;
+import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeMemberListResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleResponseDto;
 import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
 import com.mobble.mobbleserver.domain.member.entity.Member;
@@ -80,6 +81,25 @@ class LikeDispatcherServiceTest {
             assertThatThrownBy(() -> likeDispatcherService.toggleLike(LikeType.CLUB, TARGET_ID, MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(LikeErrorCode.NOT_SUPPORTED_TYPE.message());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMemberList")
+    class GetMemberListTest {
+
+        @Test
+        @DisplayName("성공 - ARTICLE 타입만 지원")
+        void success_getMemberList_article() {
+            // given
+            LikeMemberListResponseDto response = new LikeMemberListResponseDto(TARGET_ID, List.of());
+            given(mockArticleLikeQueryService.getLikedMemberList(TARGET_ID)).willReturn(response);
+
+            // when
+            LikeMemberListResponseDto result = likeDispatcherService.getMemberList(LikeType.ARTICLE, TARGET_ID);
+
+            // then
+            assertThat(result).isEqualTo(response);
         }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -1,0 +1,43 @@
+package com.mobble.mobbleserver.domain.like.baseLike.service;
+
+import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeQueryService;
+import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeService;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class LikeDispatcherServiceTest {
+
+    private MemberValidator mockMemberValidator;
+    private ArticleLikeService mockArticleLikeService;
+    private ArticleLikeQueryService mockArticleLikeQueryService;
+
+    private LikeDispatcherService likeDispatcherService;
+
+    private static final Long TARGET_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    private Member mockMember;
+
+    @BeforeEach
+    void setUp() {
+        mockMemberValidator = mock(MemberValidator.class);
+        mockArticleLikeService = mock(ArticleLikeService.class);
+        mockArticleLikeQueryService = mock(ArticleLikeQueryService.class);
+
+        likeDispatcherService = new LikeDispatcherService(
+                mockMemberValidator,
+                List.of(mockArticleLikeService),
+                List.of(mockArticleLikeQueryService)
+        );
+
+        mockMember = mock(Member.class);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -101,5 +101,15 @@ class LikeDispatcherServiceTest {
             // then
             assertThat(result).isEqualTo(response);
         }
+
+        @Test
+        @DisplayName("실패 - 지원하지 않는 LikeType")
+        void fail_getMemberList_invalidType() {
+            // when & then
+            assertThatThrownBy(() -> likeDispatcherService.getMemberList(LikeType.CLUB, TARGET_ID)
+            )
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.NOT_SUPPORTED_TYPE.message());
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -41,6 +41,10 @@ class LikeDispatcherServiceTest {
         mockArticleLikeService = mock(ArticleLikeService.class);
         mockArticleLikeQueryService = mock(ArticleLikeQueryService.class);
 
+        given(mockArticleLikeService.getType()).willReturn(LikeType.ARTICLE);
+        given(mockArticleLikeQueryService.getType()).willReturn(LikeType.ARTICLE);
+
+
         likeDispatcherService = new LikeDispatcherService(
                 mockMemberValidator,
                 List.of(mockArticleLikeService),
@@ -55,11 +59,10 @@ class LikeDispatcherServiceTest {
     class ToggleLikeTest {
 
         @Test
-        @DisplayName("성공 - ARTICLE 만 지원")
+        @DisplayName("성공 - ARTICLE 타입만 지원")
         void success_toggleLike_article() {
             // given
             given(mockMemberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
-            given(mockArticleLikeService.getType()).willReturn(LikeType.ARTICLE);
             given(mockArticleLikeService.toggleLike(TARGET_ID, mockMember)).willReturn(new LikeToggleResponseDto(TARGET_ID, true));
 
             // when

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -49,8 +49,7 @@ class LikeDispatcherServiceTest {
         likeDispatcherService = new LikeDispatcherService(
                 mockMemberValidator,
                 List.of(mockArticleLikeService),
-                List.of(mockArticleLikeQueryService)
-        );
+                List.of(mockArticleLikeQueryService));
 
         mockMember = mock(Member.class);
     }
@@ -106,8 +105,7 @@ class LikeDispatcherServiceTest {
         @DisplayName("실패 - 지원하지 않는 LikeType")
         void fail_getMemberList_invalidType() {
             // when & then
-            assertThatThrownBy(() -> likeDispatcherService.getMemberList(LikeType.CLUB, TARGET_ID)
-            )
+            assertThatThrownBy(() -> likeDispatcherService.getMemberList(LikeType.CLUB, TARGET_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(LikeErrorCode.NOT_SUPPORTED_TYPE.message());
         }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -2,14 +2,21 @@ package com.mobble.mobbleserver.domain.like.baseLike.service;
 
 import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeQueryService;
 import com.mobble.mobbleserver.domain.like.articleLike.service.ArticleLikeService;
+import com.mobble.mobbleserver.domain.like.baseLike.dto.response.LikeToggleResponseDto;
+import com.mobble.mobbleserver.domain.like.baseLike.entity.LikeType;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,5 +46,27 @@ class LikeDispatcherServiceTest {
         );
 
         mockMember = mock(Member.class);
+    }
+
+    @Nested
+    @DisplayName("toggleLike")
+    class ToggleLikeTest {
+
+        @Test
+        @DisplayName("성공 - ARTICLE 타입일 때")
+        void success_toggleLike_article() {
+            // given
+            given(mockMemberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(mockArticleLikeService.getType()).willReturn(LikeType.ARTICLE);
+            given(mockArticleLikeService.toggleLike(TARGET_ID, mockMember))
+                    .willReturn(new LikeToggleResponseDto(TARGET_ID, true));
+
+            // when
+            LikeToggleResponseDto result = likeDispatcherService.toggleLike(LikeType.ARTICLE, TARGET_ID, MEMBER_ID);
+
+            // then
+            assertThat(result.isLiked()).isTrue();
+            assertThat(result.targetId()).isEqualTo(TARGET_ID);
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/baseLike/service/LikeDispatcherServiceTest.java
@@ -69,5 +69,14 @@ class LikeDispatcherServiceTest {
             assertThat(result.isLiked()).isTrue();
             assertThat(result.targetId()).isEqualTo(TARGET_ID);
         }
+
+        @Test
+        @DisplayName("실패 - 지원하지 않는 LikeType")
+        void fail_toggleLike_invalidType() {
+            // when & then
+            assertThatThrownBy(() -> likeDispatcherService.toggleLike(LikeType.CLUB, TARGET_ID, MEMBER_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(LikeErrorCode.NOT_SUPPORTED_TYPE.message());
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -5,6 +5,9 @@ import com.mobble.mobbleserver.domain.club.core.validator.ClubValidator;
 import com.mobble.mobbleserver.domain.like.clubLike.entity.ClubLike;
 import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubValidationErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -80,5 +84,17 @@ class ClubLikeServiceTest {
         assertThat(result).isFalse();
         verify(clubLikeRepository).delete(mockClubLike);
         verify(clubLikeRepository, never()).save(any());
+    }
+
+    @DisplayName("좋아요할 클럽이 없으면 예외 발생")
+    @Test
+    void fail_when_club_not_found() {
+        // given
+        given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willThrow(new DomainException(ClubErrorCode.NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> clubLikeService.toggleLike(CLUB_ID, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ClubErrorCode.NOT_FOUND.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -55,6 +55,7 @@ class ClubLikeServiceTest {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
+
         given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
         given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
         given(clubLikeRepository.save(any(ClubLike.class))).willReturn(mockClubLike);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -49,7 +49,7 @@ class ClubLikeServiceTest {
         mockClubLike = mock(ClubLike.class);
     }
 
-    @DisplayName("좋아요가 없으면 생성")
+    @DisplayName("클럽 좋아요가 없으면 생성")
     @Test
     void success_when_not_liked() {
         // given
@@ -67,7 +67,7 @@ class ClubLikeServiceTest {
         verify(clubLikeRepository).save(any(ClubLike.class));
     }
 
-    @DisplayName("좋아요가 있으면 삭제")
+    @DisplayName("클럽 좋아요가 있으면 삭제")
     @Test
     void success_when_already_liked() {
         // given

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -73,6 +73,7 @@ class ClubLikeServiceTest {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
+        
         given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
         given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.of(mockClubLike));
 

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -64,8 +64,8 @@ class ClubLikeServiceTest {
         verify(clubLikeRepository).save(any(ClubLike.class));
     }
 
-    @Test
     @DisplayName("좋아요가 있으면 삭제")
+    @Test
     void success_when_already_liked() {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -49,8 +49,8 @@ class ClubLikeServiceTest {
         mockClubLike = mock(ClubLike.class);
     }
 
-    @DisplayName("클럽 좋아요가 없으면 생성")
     @Test
+    @DisplayName("클럽 좋아요가 없으면 생성")
     void success_when_not_liked() {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);
@@ -67,8 +67,8 @@ class ClubLikeServiceTest {
         verify(clubLikeRepository).save(any(ClubLike.class));
     }
 
-    @DisplayName("클럽 좋아요가 있으면 삭제")
     @Test
+    @DisplayName("클럽 좋아요가 있으면 삭제")
     void success_when_already_liked() {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);
@@ -86,8 +86,8 @@ class ClubLikeServiceTest {
         verify(clubLikeRepository, never()).save(any());
     }
 
-    @DisplayName("좋아요할 클럽이 없으면 예외 발생")
     @Test
+    @DisplayName("좋아요할 클럽이 없으면 예외 발생")
     void fail_when_club_not_found() {
         // given
         given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willThrow(new DomainException(ClubErrorCode.NOT_FOUND));

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ClubLikeServiceTest {
@@ -63,5 +62,23 @@ class ClubLikeServiceTest {
         // then
         assertThat(result).isTrue();
         verify(clubLikeRepository).save(any(ClubLike.class));
+    }
+
+    @Test
+    @DisplayName("좋아요가 있으면 삭제")
+    void success_when_already_liked() {
+        // given
+        given(mockClub.getId()).willReturn(CLUB_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+        given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+        given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.of(mockClubLike));
+
+        // when
+        boolean result = clubLikeService.toggleLike(CLUB_ID, mockMember).isLiked();
+
+        // then
+        assertThat(result).isFalse();
+        verify(clubLikeRepository).delete(mockClubLike);
+        verify(clubLikeRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -58,7 +58,6 @@ class ClubLikeServiceTest {
 
         given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
         given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
-        given(clubLikeRepository.save(any(ClubLike.class))).willReturn(mockClubLike);
 
         // when
         boolean result = clubLikeService.toggleLike(CLUB_ID, mockMember).isLiked();
@@ -74,7 +73,7 @@ class ClubLikeServiceTest {
         // given
         given(mockClub.getId()).willReturn(CLUB_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
-        
+
         given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
         given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.of(mockClubLike));
 

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -1,0 +1,67 @@
+package com.mobble.mobbleserver.domain.like.clubLike.service;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.validator.ClubValidator;
+import com.mobble.mobbleserver.domain.like.clubLike.entity.ClubLike;
+import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClubLikeServiceTest {
+
+    @Mock
+    ClubLikeRepository clubLikeRepository;
+
+    @Mock
+    ClubValidator clubValidator;
+
+    @InjectMocks
+    ClubLikeService clubLikeService;
+
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+
+    private Club mockClub;
+    private Member mockMember;
+    private ClubLike mockClubLike;
+
+    @BeforeEach
+    void setUp() {
+        mockClub = mock(Club.class);
+        mockMember = mock(Member.class);
+        mockClubLike = mock(ClubLike.class);
+    }
+
+    @DisplayName("좋아요가 없으면 생성")
+    @Test
+    void success_when_not_liked() {
+        // given
+        given(mockClub.getId()).willReturn(CLUB_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+        given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+        given(clubLikeRepository.findLikedByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
+        given(clubLikeRepository.save(any(ClubLike.class))).willReturn(mockClubLike);
+
+        // when
+        boolean result = clubLikeService.toggleLike(CLUB_ID, mockMember).isLiked();
+
+        // then
+        assertThat(result).isTrue();
+        verify(clubLikeRepository).save(any(ClubLike.class));
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/clubLike/service/ClubLikeServiceTest.java
@@ -7,7 +7,6 @@ import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepositor
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubErrorCode;
-import com.mobble.mobbleserver.global.exception.errorCode.club.ClubValidationErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -9,6 +9,9 @@ import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
 import com.mobble.mobbleserver.domain.like.commentLike.entity.CommentLike;
 import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -101,5 +105,17 @@ class CommentLikeServiceTest {
         assertThat(result).isFalse();
         verify(commentLikeRepository).delete(mockCommentLike);
         verify(commentLikeRepository, never()).save(any());
+    }
+
+    @DisplayName("좋아요 할 댓글이 존재하지 않으면 예외 발생")
+    @Test
+    void fail_when_comment_not_found() {
+        // given
+        given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willThrow(new DomainException(LikeErrorCode.COMMENT_REQUIRED));
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.toggleLike(COMMENT_ID, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -1,5 +1,8 @@
 package com.mobble.mobbleserver.domain.like.commentLike.service;
 
+import com.mobble.mobbleserver.domain.article.entity.Article;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.comment.entity.Comment;
 import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
@@ -7,12 +10,19 @@ import com.mobble.mobbleserver.domain.like.commentLike.entity.CommentLike;
 import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentLikeServiceTest {
@@ -29,18 +39,48 @@ class CommentLikeServiceTest {
     @InjectMocks
     CommentLikeService commentLikeService;
 
-    private static final Long CLUB_ID = 1L;
-    private static final Long MEMBER_Id = 2L;
+    private static final Long COMMENT_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
 
+    private Club mockClub;
+    private Article mockArticle;
     private Comment mockComment;
     private Member mockMember;
+    private ClubMember mockClubMember;
     private CommentLike mockCommentLike;
 
     @BeforeEach
     void setUP() {
+        mockClub = mock(Club.class);
+        mockArticle = mock(Article.class);
         mockComment = mock(Comment.class);
         mockMember = mock(Member.class);
+        mockClubMember = mock(ClubMember.class);
         mockCommentLike = mock(CommentLike.class);
     }
-    
+
+    @DisplayName("댓글 좋아요가 없으면 생성")
+    @Test
+    void success_when_not_liked() {
+        // given
+        Long clubId = 10L;
+
+        given(mockComment.getId()).willReturn(COMMENT_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+
+        given(mockComment.getArticle()).willReturn(mockArticle);
+        given(mockArticle.getClub()).willReturn(mockClub);
+        given(mockClub.getId()).willReturn(clubId);
+
+        given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+        given(commentLikeRepository.findLikedByCommentIdAndMemberId(COMMENT_ID, MEMBER_ID)).willReturn(Optional.empty());
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willReturn(mockClubMember);
+
+        // when
+        boolean result = commentLikeService.toggleLike(COMMENT_ID, mockMember).isLiked();
+
+        // then
+        assertThat(result).isTrue();
+        verify(commentLikeRepository).save(any(CommentLike.class));
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -45,6 +45,7 @@ class CommentLikeServiceTest {
 
     private static final Long COMMENT_ID = 1L;
     private static final Long MEMBER_ID = 2L;
+    private static final Long CLUB_ID = 3L;
 
     private Club mockClub;
     private Article mockArticle;
@@ -67,18 +68,16 @@ class CommentLikeServiceTest {
     @Test
     void success_when_not_liked() {
         // given
-        Long clubId = 10L;
-
         given(mockComment.getId()).willReturn(COMMENT_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
 
         given(mockComment.getArticle()).willReturn(mockArticle);
         given(mockArticle.getClub()).willReturn(mockClub);
-        given(mockClub.getId()).willReturn(clubId);
+        given(mockClub.getId()).willReturn(CLUB_ID);
 
         given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
         given(commentLikeRepository.findLikedByCommentIdAndMemberId(COMMENT_ID, MEMBER_ID)).willReturn(Optional.empty());
-        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willReturn(mockClubMember);
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(mockClubMember);
 
         // when
         boolean result = commentLikeService.toggleLike(COMMENT_ID, mockMember).isLiked();
@@ -123,17 +122,15 @@ class CommentLikeServiceTest {
     @Test
     void fail_when_not_club_member() {
         // given
-        Long clubId = 10L;
-
         given(mockComment.getId()).willReturn(COMMENT_ID);
         given(mockMember.getId()).willReturn(MEMBER_ID);
         given(mockComment.getArticle()).willReturn(mockArticle);
         given(mockArticle.getClub()).willReturn(mockClub);
-        given(mockClub.getId()).willReturn(clubId);
+        given(mockClub.getId()).willReturn(CLUB_ID);
 
         given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
         given(commentLikeRepository.findLikedByCommentIdAndMemberId(COMMENT_ID, MEMBER_ID)).willReturn(Optional.empty());
-        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> commentLikeService.toggleLike(COMMENT_ID, mockMember))

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -64,8 +64,8 @@ class CommentLikeServiceTest {
         mockCommentLike = mock(CommentLike.class);
     }
 
-    @DisplayName("댓글 좋아요가 없으면 생성")
     @Test
+    @DisplayName("댓글 좋아요가 없으면 생성")
     void success_when_not_liked() {
         // given
         given(mockComment.getId()).willReturn(COMMENT_ID);
@@ -87,8 +87,8 @@ class CommentLikeServiceTest {
         verify(commentLikeRepository).save(any(CommentLike.class));
     }
 
-    @DisplayName("댓글 좋아요가 있으면 삭제")
     @Test
+    @DisplayName("댓글 좋아요가 있으면 삭제")
     void success_when_has_liked() {
         // given
         given(mockComment.getId()).willReturn(COMMENT_ID);
@@ -106,8 +106,8 @@ class CommentLikeServiceTest {
         verify(commentLikeRepository, never()).save(any());
     }
 
-    @DisplayName("좋아요 할 댓글이 존재하지 않으면 예외 발생")
     @Test
+    @DisplayName("좋아요 할 댓글이 존재하지 않으면 예외 발생")
     void fail_when_comment_not_found() {
         // given
         given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willThrow(new DomainException(LikeErrorCode.COMMENT_REQUIRED));
@@ -118,8 +118,8 @@ class CommentLikeServiceTest {
                 .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
     }
 
-    @DisplayName("클럽 멤버가 아니면 예외 발생")
     @Test
+    @DisplayName("클럽 멤버가 아니면 예외 발생")
     void fail_when_not_club_member() {
         // given
         given(mockComment.getId()).willReturn(COMMENT_ID);

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -10,6 +10,7 @@ import com.mobble.mobbleserver.domain.like.commentLike.entity.CommentLike;
 import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberValidationErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,5 +118,27 @@ class CommentLikeServiceTest {
         assertThatThrownBy(() -> commentLikeService.toggleLike(COMMENT_ID, mockMember))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(LikeErrorCode.COMMENT_REQUIRED.message());
+    }
+
+    @DisplayName("클럽 멤버가 아니면 예외 발생")
+    @Test
+    void fail_when_not_club_member() {
+        // given
+        Long clubId = 10L;
+
+        given(mockComment.getId()).willReturn(COMMENT_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+        given(mockComment.getArticle()).willReturn(mockArticle);
+        given(mockArticle.getClub()).willReturn(mockClub);
+        given(mockClub.getId()).willReturn(clubId);
+
+        given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+        given(commentLikeRepository.findLikedByCommentIdAndMemberId(COMMENT_ID, MEMBER_ID)).willReturn(Optional.empty());
+        given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(clubId, MEMBER_ID)).willThrow(new DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.toggleLike(COMMENT_ID, mockMember))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -12,7 +12,6 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberValidationErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.like.LikeErrorCode;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -83,4 +83,23 @@ class CommentLikeServiceTest {
         assertThat(result).isTrue();
         verify(commentLikeRepository).save(any(CommentLike.class));
     }
+
+    @DisplayName("댓글 좋아요가 있으면 삭제")
+    @Test
+    void success_when_has_liked() {
+        // given
+        given(mockComment.getId()).willReturn(COMMENT_ID);
+        given(mockMember.getId()).willReturn(MEMBER_ID);
+
+        given(commentValidator.findCommentByCommentIdOrThrow(COMMENT_ID)).willReturn(mockComment);
+        given(commentLikeRepository.findLikedByCommentIdAndMemberId(COMMENT_ID, MEMBER_ID)).willReturn(Optional.of(mockCommentLike));
+
+        // when
+        boolean result = commentLikeService.toggleLike(COMMENT_ID, mockMember).isLiked();
+
+        // then
+        assertThat(result).isFalse();
+        verify(commentLikeRepository).delete(mockCommentLike);
+        verify(commentLikeRepository, never()).save(any());
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/like/commentLike/service/CommentLikeServiceTest.java
@@ -1,0 +1,46 @@
+package com.mobble.mobbleserver.domain.like.commentLike.service;
+
+import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
+import com.mobble.mobbleserver.domain.comment.entity.Comment;
+import com.mobble.mobbleserver.domain.comment.validator.CommentValidator;
+import com.mobble.mobbleserver.domain.like.commentLike.entity.CommentLike;
+import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class CommentLikeServiceTest {
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Mock
+    private CommentValidator commentValidator;
+
+    @Mock
+    private ClubMemberValidator clubMemberValidator;
+
+    @InjectMocks
+    CommentLikeService commentLikeService;
+
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_Id = 2L;
+
+    private Comment mockComment;
+    private Member mockMember;
+    private CommentLike mockCommentLike;
+
+    @BeforeEach
+    void setUP() {
+        mockComment = mock(Comment.class);
+        mockMember = mock(Member.class);
+        mockCommentLike = mock(CommentLike.class);
+    }
+    
+}


### PR DESCRIPTION
## 📄 Like 도메인 Service 로직 테스트 코드 작성
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #150 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- LikeDispatcherServiceTest: toggleLike, getMemberList 메서드 LikeType 여부에 따른 성공 / 실패 단위 테스트 코드 작성
- ArticleLikeService / ArticleLikeQueryService / ClubLikeService / CommentLikeService 단위 테스트 코드 작성
- 각 서비스 toggleLike 메서드 좋아요 생성/삭제/예외 케이스 테스트 구현
- ArticleLikeQueryService getLikedMemberList 메서드 조회/빈리스트/예외 케이스 테스트 구현

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

## 📝 기타 사항
<!-- 추가적으로 공유할 내용 -->
- 추상클래스, 인터페이스는 각 구현체에서 테스트