### PR TITLE
Test/club member entity

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -58,3 +58,17 @@ class ClubMemberTest {
             // then
             assertThat(clubMember.getJoinStatus()).isEqualTo(JoinStatus.APPROVED);
         }
+
+        @Test
+        @DisplayName("updateRole: MEMBER -> LEADER")
+        void update_role_success() {
+            // given
+            ClubMember clubMember = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+
+            // when
+            clubMember.updateRole(ClubMemberRole.LEADER);
+
+            // then
+            assertThat(clubMember.getClubMemberRole()).isEqualTo(ClubMemberRole.LEADER);
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -72,3 +72,19 @@ class ClubMemberTest {
             assertThat(clubMember.getClubMemberRole()).isEqualTo(ClubMemberRole.LEADER);
         }
     }
+
+    @Nested
+    @DisplayName("권한별 기능")
+    class Permission {
+
+        @Test
+        @DisplayName("isLeader: LEADER면 true, MEMBER면 false")
+        void is_leader_checks_role() {
+            // given
+            ClubMember leader = ClubMember.createClubMember(member, club, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+            ClubMember normal = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+
+            // then
+            assertThat(leader.isLeader()).isTrue();
+            assertThat(normal.isLeader()).isFalse();
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -31,10 +31,10 @@ class ClubMemberTest {
 
             // then
             assertThat(clubMember.getId()).isNull();
-            assertThat(clubMember.getMember()).isSameAs(member);
-            assertThat(clubMember.getClub()).isSameAs(club);
-            assertThat(clubMember.getClubMemberRole()).isEqualTo(role);
-            assertThat(clubMember.getJoinStatus()).isEqualTo(status);
+            assertThat(clubMember.getMember()).isEqualTo(member);
+            assertThat(clubMember.getClub()).isEqualTo(club);
+            assertThat(clubMember.getClubMemberRole()).isEqualTo(ClubMemberRole.MEMBER);
+            assertThat(clubMember.getJoinStatus()).isEqualTo(JoinStatus.APPROVED);
         }
     }
 

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -41,3 +41,20 @@ class ClubMemberTest {
             assertThat(clubMember.getJoinStatus()).isEqualTo(status);
         }
     }
+
+    @Nested
+    @DisplayName("상태/권한 업데이트")
+    class Update {
+
+        @Test
+        @DisplayName("updateStatus: WAITING -> APPROVED")
+        void update_status_success() {
+            // given
+            ClubMember clubMember = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.WAITING);
+
+            // when
+            clubMember.updateStatus(JoinStatus.APPROVED);
+
+            // then
+            assertThat(clubMember.getJoinStatus()).isEqualTo(JoinStatus.APPROVED);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -88,3 +88,15 @@ class ClubMemberTest {
             assertThat(leader.isLeader()).isTrue();
             assertThat(normal.isLeader()).isFalse();
         }
+
+        @Test
+        @DisplayName("canPost: NOTICE는 MEMBER 불가, LEADER 가능")
+        void can_post_notice_rule() {
+            // given
+            ClubMember leader = ClubMember.createClubMember(member, club, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+            ClubMember normal = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+
+            // then
+            assertThat(leader.canPost(ArticleType.NOTICE)).isTrue();
+            assertThat(normal.canPost(ArticleType.NOTICE)).isFalse();
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -100,3 +100,15 @@ class ClubMemberTest {
             assertThat(leader.canPost(ArticleType.NOTICE)).isTrue();
             assertThat(normal.canPost(ArticleType.NOTICE)).isFalse();
         }
+
+        @Test
+        @DisplayName("canPost: 일반 게시글(FREE)은 MEMBER도 가능")
+        void can_post_non_notice_rule() {
+            // given
+            ClubMember normal = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+
+            // then
+            assertThat(normal.canPost(ArticleType.FREE)).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -1,0 +1,43 @@
+package com.mobble.mobbleserver.domain.clubMember.entity;
+
+import com.mobble.mobbleserver.domain.article.entity.ArticleType;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.clubCategory.ClubCategoryTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClubMemberTest {
+
+    private final Member member = MemberTestFixture.createDefaultMember();
+    private final ClubCategory category = ClubCategoryTestFixture.createDefaultCategory();
+    private final Club club = ClubTestFixture.createDefaultClub(category);
+
+    @Nested
+    @DisplayName("클럽 멤버 생성")
+    class CreateClubMember {
+
+        @Test
+        @DisplayName("정상 생성")
+        void create_success() {
+            // given
+            ClubMemberRole role = ClubMemberRole.MEMBER;
+            JoinStatus status = JoinStatus.WAITING;
+
+            // when
+            ClubMember clubMember = ClubMember.createClubMember(member, club, role, status);
+
+            // then
+            assertThat(clubMember.getId()).isNull();
+            assertThat(clubMember.getMember()).isSameAs(member);
+            assertThat(clubMember.getClub()).isSameAs(club);
+            assertThat(clubMember.getClubMemberRole()).isEqualTo(role);
+            assertThat(clubMember.getJoinStatus()).isEqualTo(status);
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/entity/ClubMemberTest.java
@@ -26,12 +26,8 @@ class ClubMemberTest {
         @Test
         @DisplayName("정상 생성")
         void create_success() {
-            // given
-            ClubMemberRole role = ClubMemberRole.MEMBER;
-            JoinStatus status = JoinStatus.WAITING;
-
-            // when
-            ClubMember clubMember = ClubMember.createClubMember(member, club, role, status);
+            // given & when
+            ClubMember clubMember = ClubMember.createClubMember(member, club, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
 
             // then
             assertThat(clubMember.getId()).isNull();

--- a/src/test/java/com/mobble/mobbleserver/support/fixture/chat/chatRoom/ChatRoomTestFixture.java
+++ b/src/test/java/com/mobble/mobbleserver/support/fixture/chat/chatRoom/ChatRoomTestFixture.java
@@ -1,0 +1,12 @@
+package com.mobble.mobbleserver.support.fixture.chat.chatRoom;
+
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoomType;
+
+public final class ChatRoomTestFixture {
+    private ChatRoomTestFixture() {}
+
+    public static ChatRoom createDefaultChatRoom() {
+        return ChatRoom.createChatRoom(ChatRoomType.GROUP);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/support/fixture/chat/clubChatRoom/ClubChatRoomTestFixture.java
+++ b/src/test/java/com/mobble/mobbleserver/support/fixture/chat/clubChatRoom/ClubChatRoomTestFixture.java
@@ -1,0 +1,15 @@
+package com.mobble.mobbleserver.support.fixture.chat.clubChatRoom;
+
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.support.fixture.chat.chatRoom.ChatRoomTestFixture;
+
+public final class ClubChatRoomTestFixture {
+    private ClubChatRoomTestFixture() {}
+
+    public static ClubChatRoom createDefaultClubChatRoom(Club club) {
+        ChatRoom room = ChatRoomTestFixture.createDefaultChatRoom();
+        return ClubChatRoom.createClubChatRoom(club, room);
+    }
+}


### PR DESCRIPTION
## 📄 ClubMember 도메인 단위 테스트 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #153 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```ClubMemberTest``` 추가
  -  **클럽 멤버 생성**: ```createClubMember()``` 정상 생성 검증 (연관관계, 역할, 상태)
  - **상태/권한 업데이트**: ```updateStatus()```, ```updateRole()``` 동작 검증
  - **권한별 기능**:
    - ```isLeader()``` 역할 판별 (```LEADER``` true / ```MEMBER``` false)
    - ```canPost(ArticleType)``` 규칙 검증 (```NOTICE```는 ```LEADER```만, ```FREE```는 ```MEMBER```도 가능)

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

