### PR TITLE
Test/club member service

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -328,3 +328,31 @@ class ClubMemberServiceTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(ClubMemberErrorCode.CLUB_IS_FULL.message());
         }
+
+        @Test
+        @DisplayName("리더가 아니면 NO_PERMISSION")
+        void non_leader_no_permission() {
+            given(leader.getId()).willReturn(LEADER_ID);
+
+            ClubMember managerCM = ClubMember.createClubMember(
+                    leader, mockClub, ClubMemberRole.MANAGER, JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(TARGET_ID)).willReturn(target);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID))
+                    .willReturn(managerCM);
+
+            UpdateClubMemberStatusDto dto = new UpdateClubMemberStatusDto(TARGET_ID, JoinStatus.APPROVED);
+
+            assertThatThrownBy(() -> clubMemberService.updateClubMemberJoinStatus(CLUB_ID, LEADER_ID, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
+
+            verify(clubMemberValidator, never())
+                    .findClubMemberByClubIdAndMemberIdOrThrow(eq(CLUB_ID), eq(TARGET_ID));
+            verify(clubMemberRepository, never())
+                    .countByClubIdAndJoinStatus(anyLong(), any());
+        }
+
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -74,3 +74,29 @@ class ClubMemberServiceTest {
         leader = mock(Member.class);
         target = mock(Member.class);
     }
+    @Nested
+    @DisplayName("joinClub")
+    class JoinClub {
+
+        @Test
+        @DisplayName("자동가입 클럽이면 APPROVED로 가입")
+        void autoJoin_approved() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(mockClub.getHeadCount()).willReturn(5);
+            given(mockClub.isAutoJoin()).willReturn(true);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
+            given(clubMemberRepository.countByClubIdAndJoinStatus(CLUB_ID, JoinStatus.APPROVED)).willReturn(0L);
+
+            given(clubMemberRepository.save(any(ClubMember.class))).willAnswer(inv -> inv.getArgument(0));
+
+            ClubMemberUpsertResponseDto res = clubMemberService.joinClub(MEMBER_ID, CLUB_ID);
+
+            assertThat(res).isNotNull();
+            assertThat(res.joinStatus()).isEqualTo(JoinStatus.APPROVED);
+            assertThat(res.memberRole()).isEqualTo(ClubMemberRole.MEMBER.getDisplayName());
+
+            verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -271,3 +271,34 @@ class ClubMemberServiceTest {
         }
 
     }
+
+    @Nested
+    @DisplayName("updateClubMemberJoinStatus")
+    class UpdateJoinStatus {
+
+        @Test
+        @DisplayName("리더가 WAITING → APPROVED (정원 미초과)")
+        void approve_success() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(leader.getId()).willReturn(LEADER_ID);
+            given(target.getId()).willReturn(TARGET_ID);
+            given(mockClub.getHeadCount()).willReturn(2);
+
+            ClubMember leaderCM = ClubMember.createClubMember(leader, mockClub, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+            ClubMember targetCM = ClubMember.createClubMember(target, mockClub, ClubMemberRole.MEMBER, JoinStatus.WAITING);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(TARGET_ID)).willReturn(target);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID)).willReturn(leaderCM);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, TARGET_ID)).willReturn(targetCM);
+
+            given(clubMemberRepository.countByClubIdAndJoinStatus(CLUB_ID, JoinStatus.APPROVED)).willReturn(1L);
+
+            UpdateClubMemberStatusDto dto = new UpdateClubMemberStatusDto(TARGET_ID, JoinStatus.APPROVED);
+
+            ClubMemberUpsertResponseDto res = clubMemberService.updateClubMemberJoinStatus(CLUB_ID, LEADER_ID, dto);
+
+            assertThat(res).isNotNull();
+            assertThat(targetCM.getJoinStatus()).isEqualTo(JoinStatus.APPROVED);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -155,3 +155,23 @@ class ClubMemberServiceTest {
                     .hasMessage(ClubMemberErrorCode.CLUB_IS_FULL.message());
         }
     }
+
+    @Nested
+    @DisplayName("withdrawClub")
+    class WithdrawClub {
+
+        @Test
+        @DisplayName("가입되어 있으면 WITHDRAWN")
+        void withdraw_success() {
+            ClubMember clubMember = ClubMember.createClubMember(mockMember, mockClub, ClubMemberRole.MEMBER,
+                    JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.of(clubMember));
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)).willReturn(clubMember);
+
+            clubMemberService.withdrawClub(MEMBER_ID, CLUB_ID);
+
+            assertThat(clubMember.getJoinStatus()).isEqualTo(JoinStatus.WITHDRAWN);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -100,3 +100,26 @@ class ClubMemberServiceTest {
 
             verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
         }
+
+        @Test
+        @DisplayName("수동승인 클럽이면 WAITING으로 가입")
+        void manualJoin_waiting() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(mockClub.getHeadCount()).willReturn(10);
+            given(mockClub.isAutoJoin()).willReturn(false);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
+            given(clubMemberRepository.countByClubIdAndJoinStatus(CLUB_ID, JoinStatus.APPROVED)).willReturn(0L);
+
+            given(clubMemberRepository.save(any(ClubMember.class))).willAnswer(inv -> inv.getArgument(0));
+
+            ClubMemberUpsertResponseDto res = clubMemberService.joinClub(MEMBER_ID, CLUB_ID);
+
+            assertThat(res).isNotNull();
+            assertThat(res.joinStatus()).isEqualTo(JoinStatus.WAITING);
+            assertThat(res.memberRole()).isEqualTo(ClubMemberRole.MEMBER.getDisplayName());
+
+            verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -123,3 +123,18 @@ class ClubMemberServiceTest {
 
             verify(clubMemberRepository, times(1)).save(any(ClubMember.class));
         }
+
+        @Test
+        @DisplayName("이미 가입되어 있으면 ALREADY_JOINED")
+        void alreadyJoined_throws() {
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID))
+                    .willReturn(Optional.of(mock(ClubMember.class)));
+
+            assertThatThrownBy(() -> clubMemberService.joinClub(MEMBER_ID, CLUB_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.ALREADY_JOINED.message());
+
+            verify(clubMemberRepository, never()).save(any());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -1,0 +1,76 @@
+package com.mobble.mobbleserver.domain.clubMember.service;
+
+import com.mobble.mobbleserver.account.jwt.TokenProvider;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.validator.ClubValidator;
+import com.mobble.mobbleserver.domain.clubMember.dto.request.UpdateClubMemberRoleDto;
+import com.mobble.mobbleserver.domain.clubMember.dto.request.UpdateClubMemberStatusDto;
+import com.mobble.mobbleserver.domain.clubMember.dto.response.ClubMemberResponseDto;
+import com.mobble.mobbleserver.domain.clubMember.dto.response.ClubMemberRoleUpdateResultDto;
+import com.mobble.mobbleserver.domain.clubMember.dto.response.ClubMemberUpsertResponseDto;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
+import com.mobble.mobbleserver.domain.clubMember.entity.JoinStatus;
+import com.mobble.mobbleserver.domain.clubMember.repository.ClubMemberRepository;
+import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMemberServiceTest {
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ClubValidator clubValidator;
+
+    @Mock
+    private MemberValidator memberValidator;
+
+    @Mock
+    private ClubMemberValidator clubMemberValidator;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private ClubMemberService clubMemberService;
+
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+    private static final Long LEADER_ID = 3L;
+    private static final Long TARGET_ID = 4L;
+
+
+    private Club mockClub;
+    private Member mockMember;
+    private Member leader;
+    private Member target;
+
+    @BeforeEach
+    void setUp() {
+        mockClub = mock(Club.class);
+        mockMember = mock(Member.class);
+        leader = mock(Member.class);
+        target = mock(Member.class);
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -188,3 +188,35 @@ class ClubMemberServiceTest {
                     .hasMessage(ClubMemberErrorCode.NOT_JOINED_CLUB.message());
         }
     }
+    @Nested
+    @DisplayName("updateClubMemberRole")
+    class UpdateClubMemberRoleTest {
+
+        @Test
+        @DisplayName("리더가 권한 변경 → 토큰 재발급")
+        void leader_changes_role_and_reissues_token() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(leader.getId()).willReturn(LEADER_ID);
+            given(target.getId()).willReturn(TARGET_ID);
+
+            ClubMember leaderCM = ClubMember.createClubMember(leader, mockClub, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+            ClubMember targetCM = ClubMember.createClubMember(target, mockClub, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(TARGET_ID)).willReturn(target);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID)).willReturn(leaderCM);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, TARGET_ID)).willReturn(targetCM);
+
+            List<ClubMemberRole> roles = List.of(ClubMemberRole.LEADER, ClubMemberRole.MANAGER);
+            given(clubMemberRepository.findDistinctRolesByMemberIdAndRoleIn(eq(TARGET_ID), anyList())).willReturn(roles);
+            given(tokenProvider.createJwtToken(TARGET_ID, roles)).willReturn("jwt-token");
+
+            UpdateClubMemberRoleDto dto = new UpdateClubMemberRoleDto(TARGET_ID, ClubMemberRole.MANAGER);
+
+            ClubMemberRoleUpdateResultDto result = clubMemberService.updateClubMemberRole(CLUB_ID, LEADER_ID, dto);
+
+            assertThat(result).isNotNull();
+            assertThat(targetCM.getClubMemberRole()).isEqualTo(ClubMemberRole.MANAGER);
+            verify(tokenProvider).createJwtToken(TARGET_ID, roles);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -244,3 +244,30 @@ class ClubMemberServiceTest {
 
             verifyNoInteractions(tokenProvider);
         }
+
+        @Test
+        @DisplayName("리더가 아니면 NO_PERMISSION")
+        void non_leader_no_permission() {
+            given(leader.getId()).willReturn(LEADER_ID);
+
+            ClubMember managerCM = ClubMember.createClubMember(
+                    leader, mockClub, ClubMemberRole.MANAGER, JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(memberValidator.findMemberByMemberIdOrThrow(TARGET_ID)).willReturn(target);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID))
+                    .willReturn(managerCM);
+
+            UpdateClubMemberRoleDto dto = new UpdateClubMemberRoleDto(TARGET_ID, ClubMemberRole.MEMBER);
+
+            assertThatThrownBy(() -> clubMemberService.updateClubMemberRole(CLUB_ID, LEADER_ID, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.NO_PERMISSION.message());
+
+            verify(clubMemberValidator, never())
+                    .findClubMemberByClubIdAndMemberIdOrThrow(eq(CLUB_ID), eq(TARGET_ID));
+            verifyNoInteractions(tokenProvider);
+        }
+
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -188,6 +188,7 @@ class ClubMemberServiceTest {
                     .hasMessage(ClubMemberErrorCode.NOT_JOINED_CLUB.message());
         }
     }
+
     @Nested
     @DisplayName("updateClubMemberRole")
     class UpdateClubMemberRoleTest {
@@ -219,4 +220,27 @@ class ClubMemberServiceTest {
             assertThat(result).isNotNull();
             assertThat(targetCM.getClubMemberRole()).isEqualTo(ClubMemberRole.MANAGER);
             verify(tokenProvider).createJwtToken(TARGET_ID, roles);
+        }
+
+        @Test
+        @DisplayName("자기 자신의 권한은 변경 불가")
+        void cannot_change_own_role() {
+            given(leader.getId()).willReturn(LEADER_ID);
+
+            ClubMember leaderCM = ClubMember.createClubMember(
+                    leader, mockClub, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID))
+                    .willReturn(leaderCM);
+
+            UpdateClubMemberRoleDto dto =
+                    new UpdateClubMemberRoleDto(LEADER_ID, ClubMemberRole.MANAGER);
+
+            assertThatThrownBy(() -> clubMemberService.updateClubMemberRole(CLUB_ID, LEADER_ID, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.CANNOT_CHANGE_OWN_ROLE.message());
+
+            verifyNoInteractions(tokenProvider);
         }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -175,3 +175,16 @@ class ClubMemberServiceTest {
 
             assertThat(clubMember.getJoinStatus()).isEqualTo(JoinStatus.WITHDRAWN);
         }
+
+        @Test
+        @DisplayName("가입되어 있지 않으면 NOT_JOINED_CLUB")
+        void withdraw_notJoined_throws() {
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubMemberService.withdrawClub(MEMBER_ID, CLUB_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.NOT_JOINED_CLUB.message());
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -138,3 +138,20 @@ class ClubMemberServiceTest {
 
             verify(clubMemberRepository, never()).save(any());
         }
+
+        @Test
+        @DisplayName("정원 초과면 CLUB_IS_FULL")
+        void full_throws() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(mockClub.getHeadCount()).willReturn(3);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(mockMember);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID)).willReturn(Optional.empty());
+            given(clubMemberRepository.countByClubIdAndJoinStatus(CLUB_ID, JoinStatus.APPROVED)).willReturn(3L);
+
+            assertThatThrownBy(() -> clubMemberService.joinClub(MEMBER_ID, CLUB_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.CLUB_IS_FULL.message());
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -302,3 +302,29 @@ class ClubMemberServiceTest {
             assertThat(res).isNotNull();
             assertThat(targetCM.getJoinStatus()).isEqualTo(JoinStatus.APPROVED);
         }
+
+        @Test
+        @DisplayName("APPROVED로 변경하려는데 정원 초과 → CLUB_IS_FULL")
+        void approve_full_throws() {
+            given(mockClub.getId()).willReturn(CLUB_ID);
+            given(leader.getId()).willReturn(LEADER_ID);
+            given(target.getId()).willReturn(TARGET_ID);
+            given(mockClub.getHeadCount()).willReturn(1);
+
+            ClubMember leaderCM = ClubMember.createClubMember(leader, mockClub, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+            ClubMember targetCM = ClubMember.createClubMember(target, mockClub, ClubMemberRole.MEMBER, JoinStatus.WAITING);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(memberValidator.findMemberByMemberIdOrThrow(TARGET_ID)).willReturn(target);
+            given(memberValidator.findMemberByMemberIdOrThrow(LEADER_ID)).willReturn(leader);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, LEADER_ID)).willReturn(leaderCM);
+            given(clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, TARGET_ID)).willReturn(targetCM);
+
+            given(clubMemberRepository.countByClubIdAndJoinStatus(CLUB_ID, JoinStatus.APPROVED)).willReturn(1L);
+
+            UpdateClubMemberStatusDto dto = new UpdateClubMemberStatusDto(TARGET_ID, JoinStatus.APPROVED);
+
+            assertThatThrownBy(() -> clubMemberService.updateClubMemberJoinStatus(CLUB_ID, LEADER_ID, dto))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberErrorCode.CLUB_IS_FULL.message());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -74,6 +74,7 @@ class ClubMemberServiceTest {
         leader = mock(Member.class);
         target = mock(Member.class);
     }
+
     @Nested
     @DisplayName("joinClub")
     class JoinClub {
@@ -356,3 +357,30 @@ class ClubMemberServiceTest {
         }
 
     }
+
+    @Nested
+    @DisplayName("findClubMembers")
+    class FindClubMembers {
+
+        @Test
+        @DisplayName("클럽 멤버 목록 조회/매핑 성공")
+        void list_success() {
+            Member m1 = mock(Member.class);
+            Member m2 = mock(Member.class);
+
+            ClubMember cm1 = ClubMember.createClubMember(m1, mockClub, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+            ClubMember cm2 = ClubMember.createClubMember(m2, mockClub, ClubMemberRole.MANAGER, JoinStatus.APPROVED);
+
+            given(clubValidator.findClubByClubIdOrThrow(CLUB_ID)).willReturn(mockClub);
+            given(clubMemberRepository.findByClubId(CLUB_ID)).willReturn(List.of(cm1, cm2));
+
+            // when
+            List<ClubMemberResponseDto> res = clubMemberService.findClubMembers(CLUB_ID);
+
+            // then
+            assertThat(res).hasSize(2);
+            verify(clubMemberRepository).findByClubId(CLUB_ID);
+        }
+
+    }
+}


### PR DESCRIPTION
## 📄ClubMemberService 단위 테스트 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #154 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```ClubMemberServiceTest``` 추가 (```@ExtendWith(MockitoExtension.class)```)
- **joinClub**
  - 자동가입 → ```APPROVED```
  - 수동승인 → ```WAITING```
  - 이미 가입 → ```ALREADY_JOINED``` 예외
  - 정원 초과 → ```CLUB_IS_FULL``` 예외
- **withdrawClub**
  - 정상 탈퇴 시 ```WITHDRAWN``` 상태로 변경
  - 미가입 시 ```NOT_JOINED_CLUB``` 예외
- **updateClubMemberRole**  
  - 리더가 타 회원 권한 변경 시 역할 반영 + ```TokenProvider.createJwtToken()``` 호출 검증
  - 자기 자신 권한 변경 불가 → ```CANNOT_CHANGE_OWN_ROLE```
  - 리더가 아니면 → ```NO_PERMISSION```
- **updateClubMemberJoinStatus**
  -  리더가 ```WAITING → APPROVED```(정원 미초과) 정상 승인
  - 승인 시 정원 초과 → ```CLUB_IS_FULL```
  - 리더가 아니면 → ```NO_PERMISSION```
 - **findClubMembers**
   - 클럽 멤버 목록 조회/매핑 성공 및 Repository 호출 검증
 

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

