### PR TITLE
Test/club member validator test

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/service/ClubMemberServiceTest.java
@@ -61,7 +61,6 @@ class ClubMemberServiceTest {
     private static final Long LEADER_ID = 3L;
     private static final Long TARGET_ID = 4L;
 
-
     private Club mockClub;
     private Member mockMember;
     private Member leader;

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -94,3 +94,5 @@ class ClubMemberValidatorTest {
             verify(clubMemberRepository, times(1))
                     .findAllClubMemberByMemberId(MEMBER_ID);
         }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -1,0 +1,33 @@
+package com.mobble.mobbleserver.domain.clubMember.validator;
+
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.repository.ClubMemberRepository;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.club.ClubMemberValidationErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMemberValidatorTest {
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @InjectMocks
+    private ClubMemberValidator clubMemberValidator;
+
+    private static final Long CLUB_ID = 1L;
+    private static final Long MEMBER_ID = 2L;

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -31,6 +31,7 @@ class ClubMemberValidatorTest {
 
     private static final Long CLUB_ID = 1L;
     private static final Long MEMBER_ID = 2L;
+
     @Nested
     @DisplayName("findClubMemberByClubIdAndMemberIdOrThrow")
     class FindByClubAndMember {
@@ -70,3 +71,26 @@ class ClubMemberValidatorTest {
                     .findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
         }
     }
+
+    @Nested
+    @DisplayName("findAllClubMemberByMemberId")
+    class FindAllByMemberId {
+
+        @Test
+        @DisplayName("성공 - 멤버의 모든 클럽멤버 반환")
+        void success_return_list() {
+            // given
+            ClubMember clubMember1 = mock(ClubMember.class);
+            ClubMember clubMember2 = mock(ClubMember.class);
+            given(clubMemberRepository.findAllClubMemberByMemberId(MEMBER_ID))
+                    .willReturn(List.of(clubMember1, clubMember2));
+
+            // when
+            List<ClubMember> list = clubMemberValidator.findAllClubMemberByMemberId(MEMBER_ID);
+
+            // then
+            assertThat(list).hasSize(2)
+                    .containsExactly(clubMember1, clubMember2);
+            verify(clubMemberRepository, times(1))
+                    .findAllClubMemberByMemberId(MEMBER_ID);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -51,3 +51,22 @@ class ClubMemberValidatorTest {
             verify(clubMemberRepository, times(1))
                     .findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
         }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않으면 예외(CLUB_MEMBER_NOT_FOUND)")
+        void fail_when_not_exists() {
+            // given
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID)
+            )
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND.message());
+
+            verify(clubMemberRepository, times(1))
+                    .findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
+        }
+    }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -31,3 +31,23 @@ class ClubMemberValidatorTest {
 
     private static final Long CLUB_ID = 1L;
     private static final Long MEMBER_ID = 2L;
+    @Nested
+    @DisplayName("findClubMemberByClubIdAndMemberIdOrThrow")
+    class FindByClubAndMember {
+
+        @Test
+        @DisplayName("성공 - 존재하면 반환")
+        void success_when_exists() {
+            // given
+            ClubMember clubMember = mock(ClubMember.class);
+            given(clubMemberRepository.findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID))
+                    .willReturn(Optional.of(clubMember));
+
+            // when
+            ClubMember result = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID);
+
+            // then
+            assertThat(result).isSameAs(clubMember);
+            verify(clubMemberRepository, times(1))
+                    .findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/validator/ClubMemberValidatorTest.java
@@ -48,7 +48,7 @@ class ClubMemberValidatorTest {
             ClubMember result = clubMemberValidator.findClubMemberByClubIdAndMemberIdOrThrow(CLUB_ID, MEMBER_ID);
 
             // then
-            assertThat(result).isSameAs(clubMember);
+            assertThat(result).isEqualTo(clubMember);
             verify(clubMemberRepository, times(1))
                     .findClubMemberByClubIdAndMemberId(CLUB_ID, MEMBER_ID);
         }


### PR DESCRIPTION
## 📄 ClubMemberValidator 단위 테스트 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #161 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```ClubMemberValidatorTest``` 추가 ```(@ExtendWith(MockitoExtension.class))```
  - **findClubMemberByClubIdAndMemberIdOrThrow**
    - 존재 시 해당 ```ClubMember``` 반환
    - 미존재 시 ```DomainException(ClubMemberValidationErrorCode.CLUB_MEMBER_NOT_FOUND)``` 발생
  - **findAllClubMemberByMemberId**
    - 멤버 ID 기준 모든 ```ClubMember``` 목록 반환 및 리포지토리 호출 검증

## 📸 화면 캡처 (선택)
<!-- UI 변경이 있다면 스크린샷 첨부 -->

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인
