### PR TITLE
Test/club member repository

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImpl.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImpl.java
@@ -22,7 +22,7 @@ public class ClubMemberRepositoryImpl implements ClubMemberQueryRepository {
                 .selectFrom(clubMember)
                 .join(clubMember.club, club)
                 .fetchJoin()
-                .join(club, clubChatRoom.club)
+                .join(club.clubChatRoom, clubChatRoom)
                 .fetchJoin()
                 .join(clubChatRoom.chatRoom, chatRoom)
                 .fetchJoin()

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
@@ -1,0 +1,36 @@
+package com.mobble.mobbleserver.domain.clubMember.repository;
+
+import com.mobble.mobbleserver.config.QueryDslConfig;
+import com.mobble.mobbleserver.domain.chat.chatRoom.entity.ChatRoom;
+import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
+import com.mobble.mobbleserver.domain.clubMember.entity.JoinStatus;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.support.fixture.chat.chatRoom.ChatRoomTestFixture;
+import com.mobble.mobbleserver.support.fixture.chat.clubChatRoom.ClubChatRoomTestFixture;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class ClubMemberRepositoryImplTest {
+
+    @Autowired
+    private ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    private EntityManager em;

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
@@ -34,3 +34,61 @@ class ClubMemberRepositoryImplTest {
 
     @Autowired
     private EntityManager em;
+
+    @Nested
+    @DisplayName("findAllClubMemberByMemberId")
+    class FindAllByMemberId {
+
+        @Test
+        @DisplayName("해당 멤버가 속한 모든 클럽멤버 반환 (club/chatRoom fetch join 보장)")
+        void success_return_all_with_fetch_join() {
+            // given
+            Member m1 = MemberTestFixture.createDefaultMember();
+            Member m2 = MemberTestFixture.createDefaultMember();
+            em.persist(m1);
+            em.persist(m2);
+
+            ClubCategory cat = ClubCategory.createClubCategory("SOCCER");
+            em.persist(cat);
+
+            Club c1 = ClubTestFixture.createDefaultClub(cat);
+            Club c2 = ClubTestFixture.createDefaultClub(cat);
+            em.persist(c1);
+            em.persist(c2);
+
+            ChatRoom r1 = ChatRoomTestFixture.createDefaultChatRoom();
+            ChatRoom r2 = ChatRoomTestFixture.createDefaultChatRoom();
+            em.persist(r1);
+            em.persist(r2);
+
+            ClubChatRoom cc1 = ClubChatRoomTestFixture.createDefaultClubChatRoom(c1);
+            ClubChatRoom cc2 = ClubChatRoomTestFixture.createDefaultClubChatRoom(c2);
+            em.persist(cc1.getChatRoom());
+            em.persist(cc2.getChatRoom());
+            em.persist(cc1);
+            em.persist(cc2);
+
+            ClubMember cm11 = ClubMember.createClubMember(m1, c1, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+            ClubMember cm12 = ClubMember.createClubMember(m1, c2, ClubMemberRole.MANAGER, JoinStatus.APPROVED);
+            ClubMember cm21 = ClubMember.createClubMember(m2, c1, ClubMemberRole.MEMBER, JoinStatus.APPROVED);
+            em.persist(cm11);
+            em.persist(cm12);
+            em.persist(cm21);
+
+            em.flush();
+            em.clear();
+
+            // when
+            List<ClubMember> result = clubMemberRepository.findAllClubMemberByMemberId(m1.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+
+            ClubMember rcm1 = result.get(0);
+            assertThat(rcm1.getClub().getId()).isNotNull();
+            assertThat(rcm1.getClub().getClubChatRoom().getChatRoom().getId()).isNotNull();
+
+            assertThat(result)
+                    .extracting(cm -> cm.getClub().getId())
+                    .containsExactlyInAnyOrder(c1.getId(), c2.getId());
+        }

--- a/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/clubMember/repository/ClubMemberRepositoryImplTest.java
@@ -92,3 +92,22 @@ class ClubMemberRepositoryImplTest {
                     .extracting(cm -> cm.getClub().getId())
                     .containsExactlyInAnyOrder(c1.getId(), c2.getId());
         }
+
+        @Test
+        @DisplayName("해당 멤버가 속한 클럽이 없으면 빈 리스트")
+        void return_empty_when_none() {
+            // given
+            Member m = MemberTestFixture.createDefaultMember();
+            em.persist(m);
+
+            em.flush();
+            em.clear();
+
+            // when
+            List<ClubMember> result = clubMemberRepository.findAllClubMemberByMemberId(m.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 📄 ClubMember Repository Impl Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #155 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```success_return_all_with_fetch_join```:
  - m1이 속한 두 클럽(c1, c2)에 대해 정확히 2건 반환
  - ```getClub().getClubChatRoom().getChatRoom().getId()```가 **null** 아님 확
  - ```containsExactlyInAnyOrder```로 클럽 ID 매칭
- ```return_empty_when_none```:
  - 가입된 클럽이 없는 멤버 ID 조회 시 빈 리스트 반환
- 영속성 컨텍스트 초기화(```flush/clear```) 후 조회로 실제 쿼리 동작 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인
