### PR TITLE
Test/meeting validation

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
@@ -47,7 +47,7 @@ class MeetingValidatorTest {
 
     @Test
     @DisplayName("Meeting ID로 조회 실패 시 예외 발생")
-    void fail_when_find_meeting_by_id_or_throw() {
+    void fail_when_find_meeting_or_throw() {
         // given
         when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
@@ -1,0 +1,45 @@
+package com.mobble.mobbleserver.domain.meeting.validator;
+
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingValidatorTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @InjectMocks
+    private MeetingValidator meetingValidator;
+
+    private static final Long MEETING_ID = 1L;
+    private static final Long CLUB_ID = 2L;
+
+    @Test
+    @DisplayName("Meeting ID로 조회 성공")
+    void success_when_find_meeting_or_throw() {
+        // given
+        Meeting mockMeeting = mock(Meeting.class);
+
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.of(mockMeeting));
+
+        // when
+        Meeting result = meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID);
+
+        // then
+        assertThat(result).isEqualTo(mockMeeting);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -55,5 +56,20 @@ class MeetingValidatorTest {
         assertThatThrownBy(() -> meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID))
                 .isInstanceOf(DomainException.class)
                 .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
+    }
+
+    @Test
+    @DisplayName("Club ID로 Meeting 리스트 조회 성공")
+    void success_when_find_meetings_by_club_id() {
+        // given
+        Meeting meeting1 = mock(Meeting.class);
+        Meeting meeting2 = mock(Meeting.class);
+        when(meetingRepository.findByClubMember_Club_Id(CLUB_ID)).thenReturn(List.of(meeting1, meeting2));
+
+        // when
+        List<Meeting> result = meetingValidator.findMeetingsByClubId(CLUB_ID);
+
+        // then
+        assertThat(result).containsExactly(meeting1, meeting2);
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
@@ -2,6 +2,8 @@ package com.mobble.mobbleserver.domain.meeting.validator;
 
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingErrorCode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,5 +43,17 @@ class MeetingValidatorTest {
 
         // then
         assertThat(result).isEqualTo(mockMeeting);
+    }
+
+    @Test
+    @DisplayName("Meeting ID로 조회 실패 시 예외 발생")
+    void fail_when_find_meeting_by_id_or_throw() {
+        // given
+        when(meetingRepository.findById(MEETING_ID)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meeting/validator/MeetingValidatorTest.java
@@ -4,7 +4,6 @@ import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.repository.MeetingRepository;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingErrorCode;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,5 +71,18 @@ class MeetingValidatorTest {
 
         // then
         assertThat(result).containsExactly(meeting1, meeting2);
+    }
+
+    @Test
+    @DisplayName("Club ID로 조회 시 Meeting 이 없는 경우 빈 리스트 반환")
+    void success_when_find_meetings_by_club_id_empty_list() {
+        // given
+        when(meetingRepository.findByClubMember_Club_Id(CLUB_ID)).thenReturn(Collections.emptyList());
+
+        // when
+        List<Meeting> result = meetingValidator.findMeetingsByClubId(CLUB_ID);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
## 📄 Meeting Validation Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #171 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MeetingValidator의 주요 메서드 단위 테스트 작성
  - findMeetingByMeetingIdOrThrow() 메서드: 존재 여부에 따른 성공 / 예외 
  - findMeetingsByClubId() 메서드: 리스트 반환 및 빈 리스트 반환

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인