### PR TITLE
Test/meeting member entity

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMember.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMember.java
@@ -2,6 +2,8 @@ package com.mobble.mobbleserver.domain.meetingMember.entity;
 
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingMemberErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,6 +30,7 @@ public class MeetingMember {
 
     @Builder(access = AccessLevel.PRIVATE)
     private MeetingMember(Meeting meeting, Member member) {
+        validateMeetingMember(meeting, member);
         this.meeting = meeting;
         this.member = member;
     }
@@ -37,5 +40,10 @@ public class MeetingMember {
                 .meeting(meeting)
                 .member(member)
                 .build();
+    }
+
+    private void validateMeetingMember(Meeting meeting, Member member) {
+        if (meeting == null) throw new DomainException(MeetingMemberErrorCode.MEETING_REQUIRED);
+        if (member == null) throw new DomainException(MeetingMemberErrorCode.MEMBER_REQUIRED);
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMember.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMember.java
@@ -26,7 +26,7 @@ public class MeetingMember {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private MeetingMember(Meeting meeting, Member member) {
         this.meeting = meeting;
         this.member = member;

--- a/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/meeting/MeetingMemberErrorCode.java
+++ b/src/main/java/com/mobble/mobbleserver/global/exception/errorCode/meeting/MeetingMemberErrorCode.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum MeetingMemberErrorCode implements ErrorCode {
-    FULL_CAPACITY("더 이상 참석할 수 없습니다.", HttpStatus.CONFLICT);
+    FULL_CAPACITY("더 이상 참석할 수 없습니다.", HttpStatus.CONFLICT),
+    MEETING_REQUIRED("참석 할 모임은 필수입니다.", HttpStatus.BAD_REQUEST),
+    MEMBER_REQUIRED("참석자는 필수입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
@@ -40,4 +40,16 @@ class MeetingMemberTest {
                 .isInstanceOf(DomainException.class)
                 .hasMessage(MeetingMemberErrorCode.MEETING_REQUIRED.message());
     }
+    
+    @Test
+    @DisplayName("Member 가 null 인 경우 예외 발생")
+    void fail_when_member_is_null() {
+        // given
+        Meeting meeting = MeetingTestFixture.createDefaultMeeting();
+
+        // when & then
+        assertThatThrownBy(() -> MeetingMember.createMeetingMember(meeting, null))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(MeetingMemberErrorCode.MEMBER_REQUIRED.message());
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
@@ -1,0 +1,29 @@
+package com.mobble.mobbleserver.domain.meetingMember.entity;
+
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.support.fixture.meeting.MeetingTestFixture;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MeetingMemberTest {
+
+    @Test
+    @DisplayName("Meeting Member 생성 성공")
+    void success_create_meeting_member() {
+        // given
+        Meeting meeting = MeetingTestFixture.createDefaultMeeting();
+        Member member = MemberTestFixture.createDefaultMember();
+
+        // when
+        MeetingMember meetingMember = MeetingMember.createMeetingMember(meeting, member);
+
+        // then
+        assertThat(meetingMember).isNotNull();
+        assertThat(meetingMember.getMeeting()).isEqualTo(meeting);
+        assertThat(meetingMember.getMember()).isEqualTo(member);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
@@ -1,9 +1,17 @@
 package com.mobble.mobbleserver.domain.meetingMember.entity;
 
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMember;
+import com.mobble.mobbleserver.domain.clubMember.entity.ClubMemberRole;
+import com.mobble.mobbleserver.domain.clubMember.entity.JoinStatus;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingMemberErrorCode;
+import com.mobble.mobbleserver.support.fixture.club.ClubTestFixture;
+import com.mobble.mobbleserver.support.fixture.clubCategory.ClubCategoryTestFixture;
+import com.mobble.mobbleserver.support.fixture.clubMember.ClubMemberTestFixture;
 import com.mobble.mobbleserver.support.fixture.meeting.MeetingTestFixture;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -17,8 +25,11 @@ class MeetingMemberTest {
     @DisplayName("Meeting Member 생성 성공")
     void success_create_meeting_member() {
         // given
-        Meeting meeting = MeetingTestFixture.createDefaultMeeting();
         Member member = MemberTestFixture.createDefaultMember();
+        ClubCategory clubCategory = ClubCategoryTestFixture.createDefaultCategory();
+        Club club = ClubTestFixture.createDefaultClub(clubCategory);
+        ClubMember clubMember = ClubMemberTestFixture.createDefaultClubMember(member, club, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+        Meeting meeting = MeetingTestFixture.createDefaultMeeting(clubMember);
 
         // when
         MeetingMember meetingMember = MeetingMember.createMeetingMember(meeting, member);
@@ -40,12 +51,16 @@ class MeetingMemberTest {
                 .isInstanceOf(DomainException.class)
                 .hasMessage(MeetingMemberErrorCode.MEETING_REQUIRED.message());
     }
-    
+
     @Test
     @DisplayName("Member 가 null 인 경우 예외 발생")
     void fail_when_member_is_null() {
         // given
-        Meeting meeting = MeetingTestFixture.createDefaultMeeting();
+        Member member = MemberTestFixture.createDefaultMember();
+        ClubCategory clubCategory = ClubCategoryTestFixture.createDefaultCategory();
+        Club club = ClubTestFixture.createDefaultClub(clubCategory);
+        ClubMember clubMember = ClubMemberTestFixture.createDefaultClubMember(member, club, ClubMemberRole.LEADER, JoinStatus.APPROVED);
+        Meeting meeting = MeetingTestFixture.createDefaultMeeting(clubMember);
 
         // when & then
         assertThatThrownBy(() -> MeetingMember.createMeetingMember(meeting, null))

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/entity/MeetingMemberTest.java
@@ -2,6 +2,8 @@ package com.mobble.mobbleserver.domain.meetingMember.entity;
 
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingMemberErrorCode;
 import com.mobble.mobbleserver.support.fixture.meeting.MeetingTestFixture;
 import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -25,5 +27,17 @@ class MeetingMemberTest {
         assertThat(meetingMember).isNotNull();
         assertThat(meetingMember.getMeeting()).isEqualTo(meeting);
         assertThat(meetingMember.getMember()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("Meeting 이 null 인 경우 예외 발생")
+    void fail_when_meeting_is_null() {
+        // given
+        Member member = MemberTestFixture.createDefaultMember();
+
+        // when & then
+        assertThatThrownBy(() -> MeetingMember.createMeetingMember(null, member))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(MeetingMemberErrorCode.MEETING_REQUIRED.message());
     }
 }


### PR DESCRIPTION
## 📄 MeetingMember Entity Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #173 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MeetingMember 테스트 코드 작성
  - createMeetingMember() 생성 성공

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인