### PR TITLE
Test/meeting member service

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -1,0 +1,83 @@
+package com.mobble.mobbleserver.domain.meetingMember.service;
+
+import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
+import com.mobble.mobbleserver.domain.meeting.validator.MeetingValidator;
+import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingAttendanceResponseDto;
+import com.mobble.mobbleserver.domain.meetingMember.entity.MeetingMember;
+import com.mobble.mobbleserver.domain.meetingMember.repository.MeetingMemberRepository;
+import com.mobble.mobbleserver.domain.meetingMember.validator.MeetingMemberValidator;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingMemberServiceTest {
+
+    @Mock
+    private MeetingMemberRepository meetingMemberRepository;
+
+    @Mock
+    private MeetingValidator meetingValidator;
+
+    @Mock
+    private MeetingMemberValidator meetingMemberValidator;
+
+    @Mock
+    private MemberValidator memberValidator;
+
+    @InjectMocks
+    private MeetingMemberService meetingMemberService;
+
+    private static final Long MEETING_ID = 1L;
+    private static final Long MEMBER_ID = 10L;
+
+    private Meeting meeting;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        meeting = mock(Meeting.class);
+        member = mock(Member.class);
+    }
+
+    @Nested
+    @DisplayName("attendMeeting")
+    class AttendMeeting{
+
+        @Test
+        @DisplayName("참석 성공")
+        void success_attend_meeting() {
+            // given
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willReturn(meeting);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(member);
+            given(meetingMemberValidator.findMeetingByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.empty());
+            given(meetingMemberRepository.countByMeetingId(MEETING_ID)).willReturn(2);
+
+            given(meeting.getId()).willReturn(MEETING_ID);
+            given(meeting.getMemberLimit()).willReturn(5);
+            given(member.getId()).willReturn(MEMBER_ID);
+
+            // when
+            MeetingAttendanceResponseDto response = meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID);
+
+            // then
+            verify(meetingMemberRepository).save(any(MeetingMember.class));
+            assertThat(response.meetingId()).isEqualTo(MEETING_ID);
+            assertThat(response.isAttending()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -169,5 +169,21 @@ class MeetingMemberServiceTest {
             assertThat(response.meetingId()).isEqualTo(MEETING_ID);
             assertThat(response.meetingMembers()).hasSize(2);
         }
+
+        @Test
+        @DisplayName("미팅 참석자가 없으면 빈 리스트 반환")
+        void success_return_empty_list_when_no_attendees() {
+            // given
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willReturn(meeting);
+            given(meeting.getId()).willReturn(MEETING_ID);
+            given(meetingMemberValidator.findByMeetingId(MEETING_ID)).willReturn(List.of());
+
+            // when
+            MeetingMemberListResponseDto response = meetingMemberService.getMeetingMembers(MEETING_ID);
+
+            // then
+            assertThat(response.meetingId()).isEqualTo(MEETING_ID);
+            assertThat(response.meetingMembers()).isEmpty();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -79,5 +79,27 @@ class MeetingMemberServiceTest {
             assertThat(response.meetingId()).isEqualTo(MEETING_ID);
             assertThat(response.isAttending()).isTrue();
         }
+
+        @Test
+        @DisplayName("이미 참석한 경우 참석 취소")
+        void success_cancel_attend_meeting() {
+            // given
+            MeetingMember attending = mock(MeetingMember.class);
+
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willReturn(meeting);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(member);
+            given(meetingMemberValidator.findMeetingByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.of(attending));
+
+            given(meeting.getId()).willReturn(MEETING_ID);
+            given(member.getId()).willReturn(MEMBER_ID);
+
+            // when
+            MeetingAttendanceResponseDto response = meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID);
+
+            // then
+            verify(meetingMemberRepository).delete(attending);
+            assertThat(response.meetingId()).isEqualTo(MEETING_ID);
+            assertThat(response.isAttending()).isFalse();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -9,8 +9,8 @@ import com.mobble.mobbleserver.domain.meetingMember.validator.MeetingMemberValid
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingErrorCode;
 import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingMemberErrorCode;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -123,6 +123,18 @@ class MeetingMemberServiceTest {
             assertThatThrownBy(() -> meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(MeetingMemberErrorCode.FULL_CAPACITY.message());
+        }
+
+        @Test
+        @DisplayName("Meeting 이 존재하지 않을 경우 예외 발생")
+        void fail_when_not_found_meeting() {
+            // given
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willThrow(new DomainException(MeetingErrorCode.NOT_FOUND_MEETING));
+
+            // when & then
+            assertThatThrownBy(() -> meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
         }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -3,6 +3,7 @@ package com.mobble.mobbleserver.domain.meetingMember.service;
 import com.mobble.mobbleserver.domain.meeting.entity.Meeting;
 import com.mobble.mobbleserver.domain.meeting.validator.MeetingValidator;
 import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingAttendanceResponseDto;
+import com.mobble.mobbleserver.domain.meetingMember.dto.response.MeetingMemberListResponseDto;
 import com.mobble.mobbleserver.domain.meetingMember.entity.MeetingMember;
 import com.mobble.mobbleserver.domain.meetingMember.repository.MeetingMemberRepository;
 import com.mobble.mobbleserver.domain.meetingMember.validator.MeetingMemberValidator;
@@ -20,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +62,7 @@ class MeetingMemberServiceTest {
 
     @Nested
     @DisplayName("attendMeeting")
-    class AttendMeeting{
+    class AttendMeeting {
 
         @Test
         @DisplayName("참석 성공")
@@ -135,6 +137,37 @@ class MeetingMemberServiceTest {
             assertThatThrownBy(() -> meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMeetingMembers")
+    class GetMeetingMembers {
+
+        @Test
+        @DisplayName("미팅 참석자 목록 조회 성공")
+        void success_get_meeting_members() {
+            // given
+            Member member1 = mock(Member.class);
+            Member member2 = mock(Member.class);
+            given(member1.getId()).willReturn(100L);
+            given(member2.getId()).willReturn(101L);
+
+            MeetingMember meetingMember1 = MeetingMember.createMeetingMember(meeting, member1);
+            MeetingMember meetingMember2 = MeetingMember.createMeetingMember(meeting, member2);
+
+            List<MeetingMember> meetingMembers = List.of(meetingMember1, meetingMember2);
+
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willReturn(meeting);
+            given(meeting.getId()).willReturn(MEETING_ID);
+            given(meetingMemberValidator.findByMeetingId(MEETING_ID)).willReturn(meetingMembers);
+
+            // when
+            MeetingMemberListResponseDto response = meetingMemberService.getMeetingMembers(MEETING_ID);
+
+            // then
+            assertThat(response.meetingId()).isEqualTo(MEETING_ID);
+            assertThat(response.meetingMembers()).hasSize(2);
         }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/service/MeetingMemberServiceTest.java
@@ -8,6 +8,9 @@ import com.mobble.mobbleserver.domain.meetingMember.repository.MeetingMemberRepo
 import com.mobble.mobbleserver.domain.meetingMember.validator.MeetingMemberValidator;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.validator.MemberValidator;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.meeting.MeetingMemberErrorCode;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -100,6 +104,25 @@ class MeetingMemberServiceTest {
             verify(meetingMemberRepository).delete(attending);
             assertThat(response.meetingId()).isEqualTo(MEETING_ID);
             assertThat(response.isAttending()).isFalse();
+        }
+
+        @Test
+        @DisplayName("정원 초과 시 예외 발생")
+        void throw_exception_when_capacity_is_full() {
+            // given
+            given(meetingValidator.findMeetingByMeetingIdOrThrow(MEETING_ID)).willReturn(meeting);
+            given(memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID)).willReturn(member);
+            given(meetingMemberValidator.findMeetingByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.empty());
+            given(meetingMemberRepository.countByMeetingId(MEETING_ID)).willReturn(5);
+
+            given(meeting.getId()).willReturn(MEETING_ID);
+            given(meeting.getMemberLimit()).willReturn(5);
+            given(member.getId()).willReturn(MEMBER_ID);
+
+            // when & then
+            assertThatThrownBy(() -> meetingMemberService.attendMeeting(MEETING_ID, MEMBER_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(MeetingMemberErrorCode.FULL_CAPACITY.message());
         }
     }
 }


### PR DESCRIPTION
## 📄 MeetingMember Service Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #175 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MeetingMemberService 단위 테스트 코드 추가
  - attendMeeting(): 참석, 취소, 정원 초과, 미팅 없음 시 예외 케이스 테스트
  - getMeetingMembers(): 참석자 리스트 반환 및 빈 리스트 반환 테스트

## 📸 화면 캡처 (선택)
<!-- UI 변경이 있다면 스크린샷 첨부 -->

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인