### PR TITLE
Test/meeting member validation

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,5 +65,20 @@ class MeetingMemberValidatorTest {
         // then
         assertThat(result).isNotPresent();
         verify(meetingMemberRepository).findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("meetingId 로 MeetingMember 리스트 조회 성공")
+    void success_when_find_meeting_member_list() {
+        // given
+        List<MeetingMember> meetingMembers = List.of(meetingMember);
+        given(meetingMemberRepository.findByMeetingId(MEETING_ID)).willReturn(meetingMembers);
+
+        // when
+        List<MeetingMember> result = meetingMemberValidator.findByMeetingId(MEETING_ID);
+
+        // then
+        assertThat(result).hasSize(1).containsExactly(meetingMember);
+        verify(meetingMemberRepository).findByMeetingId(MEETING_ID);
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
@@ -39,7 +39,7 @@ class MeetingMemberValidatorTest {
 
     @Test
     @DisplayName("meetingId, memberId 로 MeetingMember 조회 성공")
-    void success_when_find_meeting_member_by_meeting_id_member_id_with_optional() {
+    void success_when_find_meeting_member_by_meeting_id_member_id() {
         // given
         given(meetingMemberRepository.findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.of(meetingMember));
 

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
@@ -51,4 +51,18 @@ class MeetingMemberValidatorTest {
         assertThat(result.get()).isEqualTo(meetingMember);
         verify(meetingMemberRepository).findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
     }
+
+    @Test
+    @DisplayName("meetingId, memberId 로 MeetingMember 조회 실패 시 Optional.empty 반환")
+    void fail_when_meeting_member_not_found() {
+        // given
+        given(meetingMemberRepository.findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.empty());
+
+        // when
+        Optional<MeetingMember> result = meetingMemberValidator.findMeetingByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
+
+        // then
+        assertThat(result).isNotPresent();
+        verify(meetingMemberRepository).findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
@@ -1,0 +1,54 @@
+package com.mobble.mobbleserver.domain.meetingMember.validation;
+
+import com.mobble.mobbleserver.domain.meetingMember.entity.MeetingMember;
+import com.mobble.mobbleserver.domain.meetingMember.repository.MeetingMemberRepository;
+import com.mobble.mobbleserver.domain.meetingMember.validator.MeetingMemberValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingMemberValidatorTest {
+
+    @Mock
+    private MeetingMemberRepository meetingMemberRepository;
+
+    @InjectMocks
+    private MeetingMemberValidator meetingMemberValidator;
+
+    private static final Long MEETING_ID = 1L;
+    private static final Long MEMBER_ID = 2L;
+
+    private MeetingMember meetingMember;
+
+    @BeforeEach
+    void setUp() {
+        meetingMember = mock(MeetingMember.class);
+    }
+
+    @Test
+    @DisplayName("meetingId, memberId 로 MeetingMember 조회 성공")
+    void success_when_find_meeting_member_by_meeting_id_member_id_with_optional() {
+        // given
+        given(meetingMemberRepository.findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.of(meetingMember));
+
+        // when
+        Optional<MeetingMember> result = meetingMemberValidator.findMeetingByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(meetingMember);
+        verify(meetingMemberRepository).findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID);
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/meetingMember/validation/MeetingMemberValidatorTest.java
@@ -39,7 +39,7 @@ class MeetingMemberValidatorTest {
     }
 
     @Test
-    @DisplayName("meetingId, memberId 로 MeetingMember 조회 성공")
+    @DisplayName("meetingId, memberId로 MeetingMember 조회 성공")
     void success_when_find_meeting_member_by_meeting_id_member_id() {
         // given
         given(meetingMemberRepository.findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.of(meetingMember));
@@ -54,7 +54,7 @@ class MeetingMemberValidatorTest {
     }
 
     @Test
-    @DisplayName("meetingId, memberId 로 MeetingMember 조회 실패 시 Optional.empty 반환")
+    @DisplayName("meetingId, memberId로 MeetingMember 조회 실패 시 Optional.empty 반환")
     void fail_when_meeting_member_not_found() {
         // given
         given(meetingMemberRepository.findMeetingMemberByMeetingIdAndMemberId(MEETING_ID, MEMBER_ID)).willReturn(Optional.empty());
@@ -68,7 +68,7 @@ class MeetingMemberValidatorTest {
     }
 
     @Test
-    @DisplayName("meetingId 로 MeetingMember 리스트 조회 성공")
+    @DisplayName("meetingId로 MeetingMember 리스트 조회 성공")
     void success_when_find_meeting_member_list() {
         // given
         List<MeetingMember> meetingMembers = List.of(meetingMember);
@@ -79,6 +79,20 @@ class MeetingMemberValidatorTest {
 
         // then
         assertThat(result).hasSize(1).containsExactly(meetingMember);
+        verify(meetingMemberRepository).findByMeetingId(MEETING_ID);
+    }
+
+    @Test
+    @DisplayName("meetingId로 조회된 MeetingMember 가 없으면 빈 리스트 반환")
+    void success_return_empty_list_when_no_attendees() {
+        // given
+        given(meetingMemberRepository.findByMeetingId(MEETING_ID)).willReturn(List.of());
+
+        // when
+        List<MeetingMember> result = meetingMemberValidator.findByMeetingId(MEETING_ID);
+
+        // then
+        assertThat(result).isEmpty();
         verify(meetingMemberRepository).findByMeetingId(MEETING_ID);
     }
 }


### PR DESCRIPTION
## 📄 MeetingMember Validator Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #181 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MeetingMemberValidator 클래스의 단위 테스트 코드 작성
  - findMeetingByMeetingIdAndMemberId
    - 존재하는 경우: Optional.of(MeetingMember) 반환
    - 존재하지 않는 경우: Optional.empty() 반환
  - findByMeetingId
    - 조회 결과 존재 시: List<MeetingMember> 반환
    - 조회 결과 없을 시: 빈 리스트 반환

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인