### PR TITLE
Test/member validation

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/repository/MemberRepository.java
@@ -13,8 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 활성 회원(isDeleted = false)만 조회하는 메소드
     Optional<Member> findByIdAndIsDeletedFalse(Long memberId);
 
-    Optional<Member> findBySocialProviderAndSocialIdAndIsDeletedFalse(SocialProvider socialProvider, String socialId);
-
     // soft-delete(isDeleted = true) 회원을 포함한 모든 회원 조회
     List<Member> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime withdrewDate);
 

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -31,13 +31,4 @@ public class MemberValidator {
                 })
                 .orElse(null); //신규 회원 이라면 null
     }
-
-    public Optional<Member> findIsDeletedFalseMemberByProviderAndSocialId(SocialProvider socialProvider, String socialId) {
-        return memberRepository.findBySocialProviderAndSocialIdAndIsDeletedFalse(socialProvider, socialId);
-    }
-
-    public Member findIsDeletedFalseMemberByProviderAndSocialIdOrThrow(SocialProvider socialProvider, String socialId) {
-        return memberRepository.findBySocialProviderAndSocialIdAndIsDeletedFalse(socialProvider, socialId)
-                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
-    }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/validator/MemberValidator.java
@@ -8,8 +8,6 @@ import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Component
 @RequiredArgsConstructor
 public class MemberValidator {

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -1,0 +1,46 @@
+package com.mobble.mobbleserver.domain.member.validator;
+
+import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class MemberValidatorTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberValidator memberValidator;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final SocialProvider SOCIAL_PROVIDER = SocialProvider.NAVER;
+    private static final String SOCIAL_ID = "123456";
+
+    @Test
+    @DisplayName("회원 조회 성공")
+    void success_when_get_member() {
+        // given
+        Member member = mock(Member.class);
+        given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.of(member));
+
+        // when
+        Member result = memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID);
+
+        // then
+        Assertions.assertThat(result).isEqualTo(member);
+    }
+
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -5,6 +5,7 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,13 @@ class MemberValidatorTest {
     private static final SocialProvider SOCIAL_PROVIDER = SocialProvider.NAVER;
     private static final String SOCIAL_ID = "123456";
 
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = mock(Member.class);
+    }
+
     @Nested
     @DisplayName("findMemberByMemberIdOrThrow")
     class FindMemberByMemberIdOrThrow {
@@ -40,7 +48,6 @@ class MemberValidatorTest {
         @DisplayName("회원 조회 성공")
         void success_when_get_member() {
             // given
-            Member member = mock(Member.class);
             given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.of(member));
 
             // when
@@ -71,7 +78,6 @@ class MemberValidatorTest {
         @DisplayName("삭제되지 않은 회원 조회 성공")
         void success_when_get_member_not_deleted() {
             // given
-            Member member = mock(Member.class);
             given(member.isDeleted()).willReturn(false);
             given(memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID)).willReturn(Optional.of(member));
 
@@ -86,7 +92,6 @@ class MemberValidatorTest {
         @DisplayName("삭제된 회원 조회시 예외 발생")
         void fail_when_get_member_deleted() {
             // given
-            Member member = mock(Member.class);
             given(member.isDeleted()).willReturn(true);
             given(memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID)).willReturn(Optional.of(member));
 

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -81,5 +81,19 @@ class MemberValidatorTest {
             // then
             assertThat(result).isEqualTo(member);
         }
+
+        @Test
+        @DisplayName("삭제된 회원 조회시 예외 발생")
+        void fail_when_get_member_deleted() {
+            // given
+            Member member = mock(Member.class);
+            given(member.isDeleted()).willReturn(true);
+            given(memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID)).willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> memberValidator.findMemberOrThrowIfDeleted(SOCIAL_PROVIDER, SOCIAL_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(MemberErrorCode.FAILED_JOIN.message());
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -3,6 +3,8 @@ package com.mobble.mobbleserver.domain.member.validator;
 import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
+import com.mobble.mobbleserver.global.exception.common.DomainException;
+import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,4 +45,15 @@ class MemberValidatorTest {
         Assertions.assertThat(result).isEqualTo(member);
     }
 
+    @Test
+    @DisplayName("회원이 존재하지 않으면 예외 발생")
+    void fail_when_member_not_found() {
+        // given
+        given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID))
+                .isInstanceOf(DomainException.class)
+                .hasMessage(MemberErrorCode.NOT_FOUND_MEMBER.message());
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -7,6 +7,7 @@ import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,29 +32,35 @@ class MemberValidatorTest {
     private static final SocialProvider SOCIAL_PROVIDER = SocialProvider.NAVER;
     private static final String SOCIAL_ID = "123456";
 
-    @Test
-    @DisplayName("회원 조회 성공")
-    void success_when_get_member() {
-        // given
-        Member member = mock(Member.class);
-        given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.of(member));
+    @Nested
+    @DisplayName("findMemberByMemberIdOrThrow")
+    class FindMemberByMemberIdOrThrow {
 
-        // when
-        Member result = memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID);
+        @Test
+        @DisplayName("회원 조회 성공")
+        void success_when_get_member() {
+            // given
+            Member member = mock(Member.class);
+            given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.of(member));
 
-        // then
-        Assertions.assertThat(result).isEqualTo(member);
+            // when
+            Member result = memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID);
+
+            // then
+            Assertions.assertThat(result).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외 발생")
+        void fail_when_member_not_found() {
+            // given
+            given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessage(MemberErrorCode.NOT_FOUND_MEMBER.message());
+        }
     }
 
-    @Test
-    @DisplayName("회원이 존재하지 않으면 예외 발생")
-    void fail_when_member_not_found() {
-        // given
-        given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.empty());
-
-        // when & then
-        Assertions.assertThatThrownBy(() -> memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID))
-                .isInstanceOf(DomainException.class)
-                .hasMessage(MemberErrorCode.NOT_FOUND_MEMBER.message());
-    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -5,7 +5,6 @@ import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -47,7 +47,7 @@ class MemberValidatorTest {
             Member result = memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID);
 
             // then
-            Assertions.assertThat(result).isEqualTo(member);
+            assertThat(result).isEqualTo(member);
         }
 
         @Test
@@ -57,10 +57,29 @@ class MemberValidatorTest {
             given(memberRepository.findByIdAndIsDeletedFalse(MEMBER_ID)).willReturn(Optional.empty());
 
             // when & then
-            Assertions.assertThatThrownBy(() -> memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID))
+            assertThatThrownBy(() -> memberValidator.findMemberByMemberIdOrThrow(MEMBER_ID))
                     .isInstanceOf(DomainException.class)
                     .hasMessage(MemberErrorCode.NOT_FOUND_MEMBER.message());
         }
     }
 
+    @Nested
+    @DisplayName("findMemberOrThrowIfDeleted")
+    class FindMemberOrThrowIfDeleted {
+
+        @Test
+        @DisplayName("삭제되지 않은 회원 조회 성공")
+        void success_when_get_member_not_deleted() {
+            // given
+            Member member = mock(Member.class);
+            given(member.isDeleted()).willReturn(false);
+            given(memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID)).willReturn(Optional.of(member));
+
+            // when
+            Member result = memberValidator.findMemberOrThrowIfDeleted(SOCIAL_PROVIDER, SOCIAL_ID);
+
+            // then
+            assertThat(result).isEqualTo(member);
+        }
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/validator/MemberValidatorTest.java
@@ -95,5 +95,18 @@ class MemberValidatorTest {
                     .isInstanceOf(DomainException.class)
                     .hasMessage(MemberErrorCode.FAILED_JOIN.message());
         }
+
+        @Test
+        @DisplayName("존재하지 않는 회원이면 null 반환")
+        void success_when_member_not_found() {
+            // given
+            given(memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID)).willReturn(Optional.empty());
+
+            // when
+            Member result = memberValidator.findMemberOrThrowIfDeleted(SOCIAL_PROVIDER, SOCIAL_ID);
+
+            // then
+            assertThat(result).isNull();
+        }
     }
 }


### PR DESCRIPTION
## 📄 MemberValidator Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #189 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MemberValidator 단위 테스트 추가
  - findMemberByMemberIdOrThrow: 회원 존재/미존재 케이스 검증
  - findMemberOrThrowIfDeleted: 정상 회원/삭제 회원/null 반환 케이스 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인