### PR TITLE
Test/member repository

### DIFF
--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -30,7 +30,7 @@ public class MemberRepositoryTest {
     private EntityManager em;
 
     private static final SocialProvider SOCIAL_PROVIDER = SocialProvider.NAVER;
-    private static final String SOCIAL_ID = "123456";
+    private static final String SOCIAL_ID = "1212";
 
     @Nested
     @DisplayName("findByIdAndIsDeletedFalse")

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -94,5 +94,24 @@ public class MemberRepositoryTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).getDeletedAt()).isBefore(standardDay);
         }
+
+        @Test
+        @DisplayName("deletedAt이 기준일 이후면 조회 실패")
+        void fail_when_deleted_after_standard_day() {
+            // given
+            LocalDateTime standardDay = LocalDateTime.now();
+            Member deletedMember = MemberTestFixture.createDefaultMember();
+            deletedMember.softDelete();
+            ReflectionTestUtils.setField(deletedMember, "deletedAt", standardDay.plusHours(1));
+            memberRepository.save(deletedMember);
+            em.flush();
+            em.clear();
+
+            // when
+            List<Member> result = memberRepository.findAllByIsDeletedTrueAndDeletedAtBefore(standardDay);
+
+            // then
+            assertThat(result).isEmpty();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -47,5 +47,20 @@ public class MemberRepositoryTest {
             assertThat(result).isPresent();
             assertThat(result.get().isDeleted()).isFalse();
         }
+
+        @Test
+        @DisplayName("삭제 회원 조회 실패")
+        void fail_when_member_is_deleted() {
+            // given
+            Member deletedMember = MemberTestFixture.createDefaultMember();
+            deletedMember.softDelete();
+            memberRepository.save(deletedMember);
+
+            // when
+            Optional<Member> result = memberRepository.findByIdAndIsDeletedFalse(deletedMember.getId());
+
+            // then
+            assertThat(result).isNotPresent();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -114,4 +114,27 @@ public class MemberRepositoryTest {
             assertThat(result).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("findBySocialProviderAndSocialId")
+    class FindBySocialProviderAndSocialId {
+
+        @Test
+        @DisplayName("socialProvider 와 socialId가 일치하면 조회 성공")
+        void success_when_provider_and_socialId_match() {
+            // given
+            Member member = MemberTestFixture.createDefaultMember();
+            memberRepository.save(member);
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<Member> result = memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getSocialProvider()).isEqualTo(SOCIAL_PROVIDER);
+            assertThat(result.get().getSocialId()).isEqualTo(SOCIAL_ID);
+        }
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -39,6 +39,8 @@ public class MemberRepositoryTest {
             // given
             Member member = MemberTestFixture.createDefaultMember();
             memberRepository.save(member);
+            em.flush();
+            em.clear();
 
             // when
             Optional<Member> result = memberRepository.findByIdAndIsDeletedFalse(member.getId());
@@ -55,6 +57,8 @@ public class MemberRepositoryTest {
             Member deletedMember = MemberTestFixture.createDefaultMember();
             deletedMember.softDelete();
             memberRepository.save(deletedMember);
+            em.flush();
+            em.clear();
 
             // when
             Optional<Member> result = memberRepository.findByIdAndIsDeletedFalse(deletedMember.getId());

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -152,5 +152,21 @@ public class MemberRepositoryTest {
             // then
             assertThat(result).isNotPresent();
         }
+
+        @Test
+        @DisplayName("socialId가 불일치하면 조회 실패")
+        void fail_when_social_id_mismatch() {
+            Member member = MemberTestFixture.createDefaultMember();
+            ReflectionTestUtils.setField(member, "socialId", "123123");
+            memberRepository.save(member);
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<Member> result = memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID);
+
+            // then
+            assertThat(result).isNotPresent();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -136,5 +136,21 @@ public class MemberRepositoryTest {
             assertThat(result.get().getSocialProvider()).isEqualTo(SOCIAL_PROVIDER);
             assertThat(result.get().getSocialId()).isEqualTo(SOCIAL_ID);
         }
+
+        @Test
+        @DisplayName("socialProvider 가 불일치하면 조회 실패")
+        void fail_when_provider_mismatch() {
+            Member member = MemberTestFixture.createDefaultMember();
+            ReflectionTestUtils.setField(member, "socialProvider", SocialProvider.KAKAO);
+            memberRepository.save(member);
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<Member> result = memberRepository.findBySocialProviderAndSocialId(SOCIAL_PROVIDER, SOCIAL_ID);
+
+            // then
+            assertThat(result).isNotPresent();
+        }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -65,6 +68,31 @@ public class MemberRepositoryTest {
 
             // then
             assertThat(result).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByIsDeletedTrueAndDeletedAtBefore")
+    class FindAllByIsDeletedTrueAndDeletedAtBefore {
+
+        @Test
+        @DisplayName("deletedAt이 기준일 이전이면 조회 성공")
+        void success_when_deleted_before_standard_day() {
+            // given
+            LocalDateTime standardDay = LocalDateTime.now();
+            Member deletedMember = MemberTestFixture.createDefaultMember();
+            deletedMember.softDelete();
+            ReflectionTestUtils.setField(deletedMember, "deletedAt", standardDay.minusHours(1));
+            memberRepository.save(deletedMember);
+            em.flush();
+            em.clear();
+
+            // when
+            List<Member> result = memberRepository.findAllByIsDeletedTrueAndDeletedAtBefore(standardDay);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getDeletedAt()).isBefore(standardDay);
         }
     }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.mobble.mobbleserver.domain.member.repository;
+
+import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
+import com.mobble.mobbleserver.config.QueryDslConfig;
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.support.fixture.member.MemberTestFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private static final SocialProvider SOCIAL_PROVIDER = SocialProvider.NAVER;
+    private static final String SOCIAL_ID = "123456";
+
+    @Nested
+    @DisplayName("findByIdAndIsDeletedFalse")
+    class FindByIdAndIsDeletedFalse {
+
+        @Test
+        @DisplayName("활성 회원 조회 성공")
+        void success_when_get_member_not_deleted() {
+            // given
+            Member member = MemberTestFixture.createDefaultMember();
+            memberRepository.save(member);
+
+            // when
+            Optional<Member> result = memberRepository.findByIdAndIsDeletedFalse(member.getId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().isDeleted()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## 📄 MemberRepository Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #191 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MemberRepository 테스트 코드 작성
  - findByIdAndIsDeletedFalse: 활성/삭제 회원 조회 검증
  - findAllByIsDeletedTrueAndDeletedAtBefore: 기준일 이전 / 이후 삭제 회원 조회 검증
  - findBySocialProviderAndSocialId: 조회 성공, 불일치 시 조회 실패 검증

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인