### PR TITLE
Test/member scheduler

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteScheduler.java
@@ -30,6 +30,7 @@ public class MemberDeleteScheduler {
 
         if (withdrewMembers.isEmpty()) {
             log.info("Not found withdrew members to delete");
+            return;
         }
         log.info("Deleting {} withdrew members.", withdrewMembers.size());
 

--- a/src/main/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteScheduler.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteScheduler.java
@@ -1,4 +1,4 @@
-package com.mobble.mobbleserver.domain.member.Scheduler;
+package com.mobble.mobbleserver.domain.member.scheduler;
 
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;

--- a/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
@@ -48,4 +48,19 @@ class MemberDeleteSchedulerTest {
                 .findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class));
         verify(memberRepository, never()).deleteAll(any());
     }
+
+    @Test
+    @DisplayName("삭제할 회원이 있으면 deleteAll 호출함")
+    void success_when_withdrew_members_exist() {
+        // given
+        given(memberRepository.findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class))).willReturn(List.of(withdrewMember));
+
+        // when
+        memberDeleteScheduler.deleteWithdrewMembers();
+
+        // then
+        verify(memberRepository, times(1))
+                .findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(memberRepository, times(1)).deleteAll(List.of(withdrewMember));
+    }
 }

--- a/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.mobble.mobbleserver.domain.member.scheduler;
+
+import com.mobble.mobbleserver.domain.member.entity.Member;
+import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberDeleteSchedulerTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberDeleteScheduler memberDeleteScheduler;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 9, 26, 18, 0);
+
+    private Member withdrewMember;
+
+    @BeforeEach
+    void setUp() {
+        withdrewMember = mock(Member.class);
+    }
+
+    @Test
+    @DisplayName("삭제할 회원이 없는 경우 deleteAll 호출하지 않음")
+    void success_when_no_withdrew_members() {
+        // given
+        given(memberRepository.findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class))).willReturn(List.of());
+
+        // when
+        memberDeleteScheduler.deleteWithdrewMembers();
+
+        // then
+        verify(memberRepository, times(1))
+                .findAllByIsDeletedTrueAndDeletedAtBefore(any(LocalDateTime.class));
+        verify(memberRepository, never()).deleteAll(any());
+    }
+}

--- a/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
+++ b/src/test/java/com/mobble/mobbleserver/domain/member/scheduler/MemberDeleteSchedulerTest.java
@@ -25,8 +25,6 @@ class MemberDeleteSchedulerTest {
     @InjectMocks
     private MemberDeleteScheduler memberDeleteScheduler;
 
-    private static final LocalDateTime NOW = LocalDateTime.of(2025, 9, 26, 18, 0);
-
     private Member withdrewMember;
 
     @BeforeEach


### PR DESCRIPTION
## 📄 MemberDeleteScheduler Test
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #193 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- MemberDeleteScheduler 로직 수정
  - 삭제할 회원이 없으면 deleteAll() 호출하지 않고 return 처리

- MemberDeleteSchedulerTest 추가
  - 삭제할 회원이 없는 경우 deleteAll() 호출하지 않음
  - 삭제할 회원이 있는 경우 deleteAll() 정상 호출

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [x] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인