### PR TITLE
Feat/ground entity

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/domain/adress/dto/request/AddressRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/dto/request/AddressRequestDto.java
@@ -1,0 +1,24 @@
+package com.mobble.mobbleserver.domain.adress.dto.request;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+
+public record AddressRequestDto(
+        String roadAddress,
+        String jibunAddress,
+        Double latitude,
+        Double longitude,
+        String detail
+) {
+
+    public Address toEntity(Club club) {
+        return Address.createAddress(
+                club,
+                this.roadAddress,
+                this.jibunAddress,
+                this.latitude,
+                this.longitude,
+                this.detail
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/dto/response/AddressResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/dto/response/AddressResponseDto.java
@@ -1,0 +1,22 @@
+package com.mobble.mobbleserver.domain.adress.dto.response;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+
+public record AddressResponseDto(
+        String roadAddress,
+        String jibunAddress,
+        Double latitude,
+        Double longitude,
+        String detail
+) {
+    public static AddressResponseDto toDto(Address address) {
+        if (address == null) return null;
+        return new AddressResponseDto(
+                address.getRoadAddress(),
+                address.getJibunAddress(),
+                address.getLatitude(),
+                address.getLongitude(),
+                address.getDetail()
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/entity/Address.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/entity/Address.java
@@ -1,0 +1,88 @@
+package com.mobble.mobbleserver.domain.adress.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
+import com.mobble.mobbleserver.domain.adress.dto.request.AddressRequestDto;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "address_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(name = "jibun_address")
+    private String jibunAddress;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "detail")
+    private String detail;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Address(
+            Club club,
+            String roadAddress,
+            String jibunAddress,
+            Double latitude,
+            Double longitude,
+            String detail
+    ) {
+        this.club = club;
+        this.roadAddress = roadAddress;
+        this.jibunAddress = jibunAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.detail = detail;
+    }
+
+    public static Address createAddress(
+            Club club,
+            String roadAddress,
+            String jibunAddress,
+            Double latitude,
+            Double longitude,
+            String detail
+    ) {
+        return Address.builder()
+                .club(club)
+                .roadAddress(roadAddress)
+                .jibunAddress(jibunAddress)
+                .latitude(latitude)
+                .longitude(longitude)
+                .detail(detail)
+                .build();
+    }
+
+    public void setClub(Club club) {
+        this.club = club;
+    }
+
+    public void updateAddress(AddressRequestDto dto) {
+        this.roadAddress = dto.roadAddress();
+        this.jibunAddress = dto.jibunAddress();
+        this.latitude = dto.latitude();
+        this.longitude = dto.longitude();
+        this.detail = dto.detail();
+    }
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/repository/AddressRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/repository/AddressRepository.java
@@ -1,0 +1,8 @@
+package com.mobble.mobbleserver.domain.adress.repository;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/entity/ClubGround.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/entity/ClubGround.java
@@ -1,0 +1,38 @@
+package com.mobble.mobbleserver.domain.club.clubGround.entity;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubGround {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_ground_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ground_code")
+    private Ground ground;
+
+    private ClubGround(Club club, Ground ground) {
+        this.club = club;
+        this.ground = ground;
+    }
+
+    public static ClubGround createClubGround(Club club, Ground ground) {
+        ClubGround clubGround = new ClubGround(club, ground);
+
+        return clubGround;
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/repository/ClubGroundRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/repository/ClubGroundRepository.java
@@ -1,0 +1,20 @@
+package com.mobble.mobbleserver.domain.club.clubGround.repository;
+
+import com.mobble.mobbleserver.domain.club.clubGround.entity.ClubGround;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ClubGroundRepository extends JpaRepository<ClubGround, Long> {
+
+    List<ClubGround> findByClubId(Long id);
+
+    void deleteAllByClubId(Long id);
+
+    @Query("SELECT cg.ground FROM ClubGround cg WHERE cg.club.id = :clubId")
+    List<Ground> findGroundsByClubId(@Param("clubId") Long clubId);
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/dto/response/GroundResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/dto/response/GroundResponseDto.java
@@ -1,0 +1,19 @@
+package com.mobble.mobbleserver.domain.ground.dto.response;
+
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+
+public record GroundResponseDto(
+        Long code,
+        String sido,
+        String sigungu,
+        String eubmyeondong
+) {
+    public static GroundResponseDto toDto(Ground ground) {
+        return new GroundResponseDto(
+                ground.getCode(),
+                ground.getSido(),
+                ground.getSigungu(),
+                ground.getEubmyeondong()
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/entity/Ground.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/entity/Ground.java
@@ -1,0 +1,27 @@
+package com.mobble.mobbleserver.domain.ground.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ground")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ground {
+
+    @Id
+    @Column(name = "ground_code", length = 20)
+    private Long code;
+
+    private String sido;
+
+    private String sigungu;
+
+    private String eubmyeondong;
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/repository/GroundRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/repository/GroundRepository.java
@@ -1,0 +1,14 @@
+package com.mobble.mobbleserver.domain.ground.repository;
+
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroundRepository extends JpaRepository<Ground, Long> {
+
+    List<Ground> findAllByCodeIn(List<Long> groundCodes);
+
+    Optional<Ground> findGroundByCode(Long groundCode);
+}


### PR DESCRIPTION
## 📄 feat: Ground 및 ClubGround 엔티티, Repository, DTO 설계
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #197 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- ```Ground``` 엔티티 생성 (```code```, ```sido```, ```sigungu```, ```eubmyeondong``` 필드 포함)
- ```GroundRepository``` 생성
- ```ClubGround``` 엔티티 생성 (```club```, ```ground``` 다대다 연결 중간 테이블)
- ```ClubGroundRepository``` 생성 (```findGroundsByClubId()``` 등 조회 메서드)
- ```GroundResponseDto``` 추가 (클럽 상세 및 검색 응답 시 사용)

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

