### PR TITLE
Feat/search club

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/dto/request/SignUpRequestDto.java
@@ -1,6 +1,7 @@
 package com.mobble.mobbleserver.account.auth.dto.request;
 
 import com.mobble.mobbleserver.account.auth.oauth.verifier.dto.SocialUserInfo;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
 import com.mobble.mobbleserver.domain.member.entity.Gender;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import jakarta.validation.constraints.*;
@@ -20,8 +21,7 @@ public record SignUpRequestDto(
         @Pattern(regexp = "^010-\\d{3,4}-\\d{4}$", message = "MEMBER:WRONG_PHONE_PATTERN")
         String phone,
 
-        @NotBlank(message = "MEMBER:REQUIRED_GROUND")
-        String ground,
+        Long groundCode,
 
         String profileImage,
 
@@ -32,14 +32,14 @@ public record SignUpRequestDto(
         boolean privacyAgreed
 ) {
 
-    public Member toEntity(SocialUserInfo userInfo) {
+    public Member toEntity(SocialUserInfo userInfo, Ground ground) {
         return Member.createMember(
                 this.name,
                 this.age,
                 this.gender,
                 userInfo.email(),
                 this.phone,
-                this.ground,
+                ground,
                 this.profileImage,
                 this.termsAgreed,
                 this.privacyAgreed,

--- a/src/main/java/com/mobble/mobbleserver/account/auth/service/SignUpDetailsInfoService.java
+++ b/src/main/java/com/mobble/mobbleserver/account/auth/service/SignUpDetailsInfoService.java
@@ -2,8 +2,10 @@ package com.mobble.mobbleserver.account.auth.service;
 
 import com.mobble.mobbleserver.account.auth.dto.request.SignUpRequestDto;
 import com.mobble.mobbleserver.account.auth.dto.response.SignUpDetailsInfoResponseDto;
-import com.mobble.mobbleserver.account.jwt.TokenProvider;
 import com.mobble.mobbleserver.account.auth.oauth.verifier.dto.SocialUserInfo;
+import com.mobble.mobbleserver.account.jwt.TokenProvider;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import com.mobble.mobbleserver.domain.ground.repository.GroundRepository;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 import com.mobble.mobbleserver.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ public class SignUpDetailsInfoService {
 
     private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
+    private final GroundRepository groundRepository;
 
     public SignUpDetailsInfoResponseDto getSocialUserInfo(String signupToken) {
         SocialUserInfo userInfo = tokenProvider.getSignupTokenInfo(signupToken);
@@ -27,7 +30,8 @@ public class SignUpDetailsInfoService {
     @Transactional
     public String signup(String signupToken, SignUpRequestDto dto) {
         SocialUserInfo userInfo = tokenProvider.getSignupTokenInfo(signupToken);
-        Member member = dto.toEntity(userInfo);
+        Ground ground = groundRepository.findGroundByCode(dto.groundCode()).get();
+        Member member = dto.toEntity(userInfo,ground);
         memberRepository.save(member);
 
         return tokenProvider.createJwtToken(member.getId());

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/dto/request/AddressRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/dto/request/AddressRequestDto.java
@@ -1,0 +1,24 @@
+package com.mobble.mobbleserver.domain.adress.dto.request;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+
+public record AddressRequestDto(
+        String roadAddress,
+        String jibunAddress,
+        Double latitude,
+        Double longitude,
+        String detail
+) {
+
+    public Address toEntity(Club club) {
+        return Address.createAddress(
+                club,
+                this.roadAddress,
+                this.jibunAddress,
+                this.latitude,
+                this.longitude,
+                this.detail
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/dto/response/AddressResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/dto/response/AddressResponseDto.java
@@ -1,0 +1,22 @@
+package com.mobble.mobbleserver.domain.adress.dto.response;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+
+public record AddressResponseDto(
+        String roadAddress,
+        String jibunAddress,
+        Double latitude,
+        Double longitude,
+        String detail
+) {
+    public static AddressResponseDto toDto(Address address) {
+        if (address == null) return null;
+        return new AddressResponseDto(
+                address.getRoadAddress(),
+                address.getJibunAddress(),
+                address.getLatitude(),
+                address.getLongitude(),
+                address.getDetail()
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/entity/Address.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/entity/Address.java
@@ -1,0 +1,88 @@
+package com.mobble.mobbleserver.domain.adress.entity;
+
+import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
+import com.mobble.mobbleserver.domain.adress.dto.request.AddressRequestDto;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "address_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(name = "jibun_address")
+    private String jibunAddress;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "detail")
+    private String detail;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Address(
+            Club club,
+            String roadAddress,
+            String jibunAddress,
+            Double latitude,
+            Double longitude,
+            String detail
+    ) {
+        this.club = club;
+        this.roadAddress = roadAddress;
+        this.jibunAddress = jibunAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.detail = detail;
+    }
+
+    public static Address createAddress(
+            Club club,
+            String roadAddress,
+            String jibunAddress,
+            Double latitude,
+            Double longitude,
+            String detail
+    ) {
+        return Address.builder()
+                .club(club)
+                .roadAddress(roadAddress)
+                .jibunAddress(jibunAddress)
+                .latitude(latitude)
+                .longitude(longitude)
+                .detail(detail)
+                .build();
+    }
+
+    public void setClub(Club club) {
+        this.club = club;
+    }
+
+    public void updateAddress(AddressRequestDto dto) {
+        this.roadAddress = dto.roadAddress();
+        this.jibunAddress = dto.jibunAddress();
+        this.latitude = dto.latitude();
+        this.longitude = dto.longitude();
+        this.detail = dto.detail();
+    }
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/adress/repository/AddressRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/adress/repository/AddressRepository.java
@@ -1,0 +1,8 @@
+package com.mobble.mobbleserver.domain.adress.repository;
+
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/entity/ClubGround.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/entity/ClubGround.java
@@ -1,0 +1,38 @@
+package com.mobble.mobbleserver.domain.club.clubGround.entity;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubGround {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_ground_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ground_code")
+    private Ground ground;
+
+    private ClubGround(Club club, Ground ground) {
+        this.club = club;
+        this.ground = ground;
+    }
+
+    public static ClubGround createClubGround(Club club, Ground ground) {
+        ClubGround clubGround = new ClubGround(club, ground);
+
+        return clubGround;
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/repository/ClubGroundRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/clubGround/repository/ClubGroundRepository.java
@@ -1,0 +1,20 @@
+package com.mobble.mobbleserver.domain.club.clubGround.repository;
+
+import com.mobble.mobbleserver.domain.club.clubGround.entity.ClubGround;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ClubGroundRepository extends JpaRepository<ClubGround, Long> {
+
+    List<ClubGround> findByClubId(Long id);
+
+    void deleteAllByClubId(Long id);
+
+    @Query("SELECT cg.ground FROM ClubGround cg WHERE cg.club.id = :clubId")
+    List<Ground> findGroundsByClubId(@Param("clubId") Long clubId);
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/dto/request/ClubRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/dto/request/ClubRequestDto.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.club.core.dto.request;
 
+import com.mobble.mobbleserver.domain.adress.dto.request.AddressRequestDto;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroupType;
 import com.mobble.mobbleserver.domain.club.core.entity.Club;
 import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
@@ -18,11 +19,9 @@ public record ClubRequestDto(
 //        String profileImage,
 //        List<String> infoImage,
 
-        @NotBlank(message = "CLUB:GROUND_NOT_BLANK")
-        String ground,
+        AddressRequestDto addressDto,
 
-        @NotBlank(message = "CLUB:ADDRESS_NOT_BLANK")
-        String address,
+        List<Long> groundCodes,
 
         @Min(value = 2, message = "CLUB:HEADCOUNT_MIN")
         @Max(value = 1000, message = "CLUB:HEADCOUNT_MAX")
@@ -39,8 +38,6 @@ public record ClubRequestDto(
         return Club.createClub(
                 clubCategory,
                 this.name,
-                this.ground,
-                this.address,
                 this.headcount,
                 this.isAutoJoin
         );

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/dto/response/ClubResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/dto/response/ClubResponseDto.java
@@ -1,8 +1,11 @@
 package com.mobble.mobbleserver.domain.club.core.dto.response;
 
+import com.mobble.mobbleserver.domain.adress.dto.response.AddressResponseDto;
+import com.mobble.mobbleserver.domain.adress.entity.Address;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroupType;
 import com.mobble.mobbleserver.domain.club.core.entity.Club;
 import com.mobble.mobbleserver.domain.club.core.repository.dto.ClubLikeInfoDto;
+import com.mobble.mobbleserver.domain.ground.dto.response.GroundResponseDto;
 
 import java.util.List;
 
@@ -11,8 +14,8 @@ public record ClubResponseDto(
         String leader,
         String name,
         String category,
-        String ground,
-        String address,
+        List<GroundResponseDto> groundList,
+        AddressResponseDto address,
         int headcount,
         List<AgeGroupType> ageGroup,
 //        String profileImage,
@@ -25,7 +28,9 @@ public record ClubResponseDto(
     public static ClubResponseDto toDto(
             Club club,
             String leaderName,
+            Address address,
             List<AgeGroupType> ageGroup,
+            List<GroundResponseDto> groundList,
             ClubLikeInfoDto likeInfo
     ){
         return new ClubResponseDto(
@@ -33,8 +38,8 @@ public record ClubResponseDto(
                 leaderName,
                 club.getName(),
                 club.getClubCategory().getName(),
-                club.getGround(),
-                club.getAddress(),
+                groundList,
+                AddressResponseDto.toDto(address),
                 club.getHeadCount(),
                 ageGroup,
                 likeInfo.likeCount(),

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/entity/Club.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/entity/Club.java
@@ -1,6 +1,7 @@
 package com.mobble.mobbleserver.domain.club.core.entity;
 
 import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
+import com.mobble.mobbleserver.domain.adress.entity.Address;
 import com.mobble.mobbleserver.domain.chat.clubChatRoom.entity.ClubChatRoom;
 import com.mobble.mobbleserver.domain.clubCategory.entity.ClubCategory;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
@@ -31,12 +32,8 @@ public class Club extends BaseEntity {
 //    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private final List<ClubImage> clubImages = new ArrayList<>();
 
-    // Todo: 지역관리를 위해 추후 Enum 또는 테이블로 관리해야함.
-    @Column(name = "ground")
-    private String ground;
-
-    @Column(name = "address")
-    private String address;
+    @OneToOne(mappedBy = "club", fetch = FetchType.LAZY)
+    private Address address;
 
     @Column(name = "head_count")
     private int headCount;
@@ -51,16 +48,12 @@ public class Club extends BaseEntity {
     private Club(
             ClubCategory category,
             String name,
-            String ground,
-            String address,
             int headCount,
             boolean isAutoJoin
     ) {
-        validateCommon(category, name, ground, address, headCount);
+        validateCommon(category, name, headCount);
         this.clubCategory = category;
         this.name = name;
-        this.ground = ground;
-        this.address = address;
         this.headCount = headCount;
         this.isAutoJoin = isAutoJoin;
     }
@@ -68,16 +61,12 @@ public class Club extends BaseEntity {
     public static Club createClub(
             ClubCategory category,
             String name,
-            String ground,
-            String address,
             int headCount,
             boolean isAutoJoin
     ) {
         return Club.builder()
                 .category(category)
                 .name(name)
-                .ground(ground)
-                .address(address)
                 .headCount(headCount)
                 .isAutoJoin(isAutoJoin)
                 .build();
@@ -90,15 +79,13 @@ public class Club extends BaseEntity {
     public void updateClub(
             ClubCategory category,
             String name,
-            String ground,
-            String address,
+            Address address,
             int headCount,
             boolean isAutoJoin
     ) {
-        validateCommon(category, name, ground, address, headCount);
+        validateCommon(category, name, headCount);
         this.clubCategory = category;
         this.name = name;
-        this.ground = ground;
         this.address = address;
         this.headCount = headCount;
         this.isAutoJoin = isAutoJoin;
@@ -107,14 +94,15 @@ public class Club extends BaseEntity {
     private void validateCommon(
             ClubCategory category,
             String name,
-            String ground,
-            String address,
             int headCount
     ) {
         if (category == null) throw new DomainException(ClubErrorCode.CATEGORY_REQUIRED);
         if (name == null || name.isBlank()) throw new DomainException(ClubErrorCode.NAME_REQUIRED);
-        if (ground == null || ground.isBlank()) throw new DomainException(ClubErrorCode.GROUND_REQUIRED);
-        if (address == null || address.isBlank()) throw new DomainException(ClubErrorCode.ADDRESS_REQUIRED);
         if (headCount <= 0) throw new DomainException(ClubErrorCode.HEADCOUNT_REQUIRED);
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+        address.setClub(this);
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -131,14 +131,29 @@ public class ClubService {
                 .orElseThrow(() -> new DomainException(ClubErrorCode.CATEGORY_NOT_FOUND));
     }
 
-    private ClubResponseDto buildClubResponse(Club club, Member member, String leaderName) {
+    private ClubResponseDto buildClubResponse(
+            Club club,
+            Member member,
+            String leaderName
+    ) {
         List<AgeGroupType> ageGroupList = ageGroupRepository.findByClubId(club.getId()).stream()
                 .map(AgeGroup::getAgeGroupType)
                 .toList();
 
+        List<Long> groundCodes = clubGroundRepository.findByClubId(club.getId())
+                .stream()
+                .map(cg -> cg.getGround().getCode())
+                .collect(Collectors.toList());
+
+        List<GroundResponseDto> groundList = groundRepository.findAllByCodeIn(groundCodes)
+                .stream()
+                .map(GroundResponseDto::toDto)
+                .toList();
+
+        Address address = club.getAddress();
         ClubLikeInfoDto likeInfo = clubRepository.findLikeInfoByClubIdAndMemberId(club.getId(), member.getId());
 
-        return ClubResponseDto.toDto(club, leaderName, ageGroupList, likeInfo);
+        return ClubResponseDto.toDto(club, leaderName, address, ageGroupList, groundList, likeInfo);
     }
 
     private List<AgeGroup> createClubAgeGroups(Club club, List<AgeGroupType> ageGroupTypes) {

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -162,6 +162,13 @@ public class ClubService {
                 .toList();
     }
 
+    private List<ClubGround> createClubGroundList(List<Long> codeList, Club club) {
+        List<Ground> grounds = groundRepository.findAllById(codeList);
+        return grounds.stream()
+                .map(g -> ClubGround.createClubGround(club, g))
+                .toList();
+    }
+
     private void assertLeader(ClubMember clubMember) {
         if (!clubMember.isLeader()) throw new DomainException(ClubMemberErrorCode.NO_PERMISSION);
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -50,6 +50,9 @@ public class ClubService {
     private final CommentLikeRepository commentLikeRepository;
     private final ArticleLikeRepository articleLikeRepository;
     private final ClubLikeRepository clubLikeRepository;
+    private final AddressRepository addressRepository;
+    private final GroundRepository groundRepository;
+    private final ClubGroundRepository clubGroundRepository;
 
     private final ClubValidator clubValidator;
     private final MemberValidator memberValidator;
@@ -63,6 +66,14 @@ public class ClubService {
         Club club = dto.toEntity(category);
         clubRepository.save(club);
 
+        Address address = dto.addressDto().toEntity(club);
+        addressRepository.save(address);
+        club.setAddress(address);
+
+        List<Long> codeList = dto.groundCodes();
+        List<ClubGround> clubGrounds = createClubGroundList(codeList, club);
+        clubGroundRepository.saveAll(clubGrounds);
+
         ClubMember clubMember = ClubMember.createClubMember(member, club, ClubMemberRole.LEADER, JoinStatus.APPROVED);
         clubMemberRepository.save(clubMember);
 
@@ -70,7 +81,8 @@ public class ClubService {
         ageGroupRepository.saveAll(ageGroups);
 
         // Todo: 반환값이 Club 채팅방의 preview 에 필요한 데이터이기 때문에 반환 DTO에 포함 되어야 함
-        ClubChatRoomPreviewResponseDto clubChatRoom = clubChatRoomService.createClubChatRoom(club.getId(), member.getId());
+        ClubChatRoomPreviewResponseDto clubChatRoom = clubChatRoomService.createClubChatRoom(club.getId(),
+                member.getId());
 
         return buildClubResponse(club, member, member.getName());
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/core/service/ClubService.java
@@ -1,11 +1,16 @@
 package com.mobble.mobbleserver.domain.club.core.service;
 
+import com.mobble.mobbleserver.domain.adress.dto.request.AddressRequestDto;
+import com.mobble.mobbleserver.domain.adress.entity.Address;
+import com.mobble.mobbleserver.domain.adress.repository.AddressRepository;
 import com.mobble.mobbleserver.domain.article.repository.ArticleRepository;
 import com.mobble.mobbleserver.domain.chat.clubChatRoom.dto.response.ClubChatRoomPreviewResponseDto;
 import com.mobble.mobbleserver.domain.chat.clubChatRoom.service.ClubChatRoomService;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroup;
 import com.mobble.mobbleserver.domain.club.ageGroup.entity.AgeGroupType;
 import com.mobble.mobbleserver.domain.club.ageGroup.repository.AgeGroupRepository;
+import com.mobble.mobbleserver.domain.club.clubGround.entity.ClubGround;
+import com.mobble.mobbleserver.domain.club.clubGround.repository.ClubGroundRepository;
 import com.mobble.mobbleserver.domain.club.core.dto.request.ClubRequestDto;
 import com.mobble.mobbleserver.domain.club.core.dto.response.ClubResponseDto;
 import com.mobble.mobbleserver.domain.club.core.entity.Club;
@@ -20,6 +25,9 @@ import com.mobble.mobbleserver.domain.clubMember.entity.JoinStatus;
 import com.mobble.mobbleserver.domain.clubMember.repository.ClubMemberRepository;
 import com.mobble.mobbleserver.domain.clubMember.validator.ClubMemberValidator;
 import com.mobble.mobbleserver.domain.comment.repository.CommentRepository;
+import com.mobble.mobbleserver.domain.ground.dto.response.GroundResponseDto;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import com.mobble.mobbleserver.domain.ground.repository.GroundRepository;
 import com.mobble.mobbleserver.domain.like.articleLike.repository.ArticleLikeRepository;
 import com.mobble.mobbleserver.domain.like.clubLike.repository.ClubLikeRepository;
 import com.mobble.mobbleserver.domain.like.commentLike.repository.CommentLikeRepository;
@@ -33,6 +41,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -106,11 +115,20 @@ public class ClubService {
         assertLeader(clubMember);
 
         ClubCategory category = findCategoryOrThrow(dto.category());
-        club.updateClub(category, dto.name(), dto.ground(), dto.address(), dto.headcount(), dto.isAutoJoin());
+
+        Address address = club.getAddress();
+        AddressRequestDto addrDto = dto.addressDto();
+
+        address.updateAddress(addrDto);
+        club.updateClub(category, dto.name(), address, dto.headcount(), dto.isAutoJoin());
 
         ageGroupRepository.deleteAllClubAgeGroupByClubId(club.getId());
+        clubGroundRepository.deleteAllByClubId(club.getId());
+
         List<AgeGroup> newAgeGroups = createClubAgeGroups(club, dto.ageGroup());
+        List<ClubGround> newClubGrounds = createClubGroundList(dto.groundCodes(), club);
         ageGroupRepository.saveAll(newAgeGroups);
+        clubGroundRepository.saveAll(newClubGrounds);
 
         return buildClubResponse(club, member, member.getName());
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/club/search/contorller/ClubSearchController.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/search/contorller/ClubSearchController.java
@@ -1,0 +1,34 @@
+package com.mobble.mobbleserver.domain.club.search.contorller;
+
+import com.mobble.mobbleserver.domain.club.search.dto.request.ClubSearchRequestDto;
+import com.mobble.mobbleserver.domain.club.search.dto.response.ClubSummaryDto;
+import com.mobble.mobbleserver.domain.club.search.service.ClubSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search/clubs")
+public class ClubSearchController {
+
+    private final ClubSearchService clubSearchService;
+
+    @GetMapping
+    public ResponseEntity<List<ClubSummaryDto>> searchClubs(
+            @Validated ClubSearchRequestDto dto,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId
+            ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(clubSearchService.searchClubs(dto, memberId));
+    }
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/search/dto/request/ClubSearchRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/search/dto/request/ClubSearchRequestDto.java
@@ -1,0 +1,15 @@
+package com.mobble.mobbleserver.domain.club.search.dto.request;
+
+public record ClubSearchRequestDto(
+        String name,
+        Long groundCode,
+        Double latitude,
+        Double longitude,
+        Double distanceKm,
+        String category,
+        String ageGroup,
+        Boolean isAutoJoin,
+        String sort
+){
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/search/dto/response/ClubSummaryDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/search/dto/response/ClubSummaryDto.java
@@ -1,0 +1,44 @@
+package com.mobble.mobbleserver.domain.club.search.dto.response;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.repository.dto.ClubLikeInfoDto;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+
+import java.util.List;
+
+public record ClubSummaryDto(
+        Long id,
+        String name,
+        String category,
+        List<String> groundNames,
+        int headcount,
+        int likeCount,
+        boolean liked,
+        boolean isAutoJoin
+) {
+
+    public static ClubSummaryDto toDto(
+            Club club,
+            List<Ground> groundList,
+            ClubLikeInfoDto likeInfo
+    ) {
+        List<String> groundNames = groundList.stream()
+                .map(g -> buildGroundName(g))
+                .toList();
+
+        return new ClubSummaryDto(
+                club.getId(),
+                club.getName(),
+                club.getClubCategory().getName(),
+                groundNames,
+                club.getHeadCount(),
+                likeInfo.likeCount(),
+                likeInfo.isLiked(),
+                club.isAutoJoin()
+        );
+    }
+
+    private static String buildGroundName(Ground g) {
+        return g.getEubmyeondong() != null ? g.getEubmyeondong() : "";
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/search/repository/ClubSearchRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/search/repository/ClubSearchRepository.java
@@ -1,0 +1,65 @@
+package com.mobble.mobbleserver.domain.club.search.repository;
+
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.search.dto.request.ClubSearchRequestDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.mobble.mobbleserver.domain.adress.entity.QAddress.address;
+import static com.mobble.mobbleserver.domain.club.clubGround.entity.QClubGround.clubGround;
+import static com.mobble.mobbleserver.domain.club.core.entity.QClub.club;
+import static com.mobble.mobbleserver.domain.clubCategory.entity.QClubCategory.clubCategory;
+import static com.mobble.mobbleserver.domain.ground.entity.QGround.ground;
+import static com.mobble.mobbleserver.domain.like.clubLike.entity.QClubLike.clubLike;
+
+@Repository
+@RequiredArgsConstructor
+public class ClubSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Club> searchClubs(ClubSearchRequestDto req) {
+        var query = queryFactory
+                .selectFrom(club)
+                .leftJoin(club.address, address).fetchJoin()
+                .leftJoin(club.clubCategory, clubCategory).fetchJoin()
+                .leftJoin(clubGround).on(clubGround.club.eq(club))
+                .leftJoin(clubGround.ground, ground)
+                .leftJoin(clubLike).on(clubLike.club.eq(club));
+
+        if (req.name() != null && !req.name().isBlank()) {
+            query.where(club.name.containsIgnoreCase(req.name()));
+        }
+        if (req.category() != null) {
+            query.where(clubCategory.name.eq(req.category()));
+        }
+        if (req.isAutoJoin() != null) {
+            query.where(club.isAutoJoin.eq(req.isAutoJoin()));
+        }
+        if (req.groundCode() != null) {
+            query.where(ground.code.eq(req.groundCode()));
+        }
+        if (req.latitude() != null && req.longitude() != null && req.distanceKm() != null) {
+            query.where(
+                    address.latitude.subtract(req.latitude())
+                            .multiply(address.latitude.subtract(req.latitude()))
+                            .add(address.longitude.subtract(req.longitude())
+                                    .multiply(address.longitude.subtract(req.longitude())))
+                            .loe(req.distanceKm())
+            );
+        }
+
+        if (req.sort() != null) {
+            switch (req.sort().toUpperCase()) {
+                case "LATEST" -> query.orderBy(club.createdAt.desc());
+                case "LIKE" -> query.groupBy(club.id).orderBy(clubLike.count().desc());
+                case "MEMBER" -> query.orderBy(club.headCount.desc());
+            }
+        }
+
+        return query.fetch();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/club/search/service/ClubSearchService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/club/search/service/ClubSearchService.java
@@ -1,0 +1,37 @@
+package com.mobble.mobbleserver.domain.club.search.service;
+
+import com.mobble.mobbleserver.domain.club.clubGround.repository.ClubGroundRepository;
+import com.mobble.mobbleserver.domain.club.core.entity.Club;
+import com.mobble.mobbleserver.domain.club.core.repository.ClubRepository;
+import com.mobble.mobbleserver.domain.club.core.repository.dto.ClubLikeInfoDto;
+import com.mobble.mobbleserver.domain.club.search.dto.request.ClubSearchRequestDto;
+import com.mobble.mobbleserver.domain.club.search.dto.response.ClubSummaryDto;
+import com.mobble.mobbleserver.domain.club.search.repository.ClubSearchRepository;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubSearchService {
+
+    private final ClubSearchRepository clubSearchRepository;
+    private final ClubRepository clubRepository;
+    private final ClubGroundRepository clubGroundRepository;
+
+    public List<ClubSummaryDto> searchClubs(ClubSearchRequestDto dto, Long memberId) {
+        List<Club> clubs = clubSearchRepository.searchClubs(dto);
+
+        return clubs.stream()
+                .map(club -> {
+                    List<Ground> groundList = clubGroundRepository.findGroundsByClubId(club.getId());
+                    ClubLikeInfoDto likeInfo = clubRepository.findLikeInfoByClubIdAndMemberId(club.getId(), memberId);
+                    return ClubSummaryDto.toDto(club, groundList, likeInfo);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/dto/response/GroundResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/dto/response/GroundResponseDto.java
@@ -1,0 +1,19 @@
+package com.mobble.mobbleserver.domain.ground.dto.response;
+
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+
+public record GroundResponseDto(
+        Long code,
+        String sido,
+        String sigungu,
+        String eubmyeondong
+) {
+    public static GroundResponseDto toDto(Ground ground) {
+        return new GroundResponseDto(
+                ground.getCode(),
+                ground.getSido(),
+                ground.getSigungu(),
+                ground.getEubmyeondong()
+        );
+    }
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/entity/Ground.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/entity/Ground.java
@@ -1,0 +1,27 @@
+package com.mobble.mobbleserver.domain.ground.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ground")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ground {
+
+    @Id
+    @Column(name = "ground_code", length = 20)
+    private Long code;
+
+    private String sido;
+
+    private String sigungu;
+
+    private String eubmyeondong;
+
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/ground/repository/GroundRepository.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/ground/repository/GroundRepository.java
@@ -1,0 +1,14 @@
+package com.mobble.mobbleserver.domain.ground.repository;
+
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroundRepository extends JpaRepository<Ground, Long> {
+
+    List<Ground> findAllByCodeIn(List<Long> groundCodes);
+
+    Optional<Ground> findGroundByCode(Long groundCode);
+}

--- a/src/main/java/com/mobble/mobbleserver/domain/member/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/dto/request/MemberUpdateRequestDto.java
@@ -1,4 +1,4 @@
 package com.mobble.mobbleserver.domain.member.dto.request;
 
-public record MemberUpdateRequestDto(String ground, String profileImage) {
+public record MemberUpdateRequestDto(Long groundCode, String profileImage) {
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/dto/response/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.mobble.mobbleserver.domain.member.dto.response;
 
+import com.mobble.mobbleserver.domain.ground.dto.response.GroundResponseDto;
 import com.mobble.mobbleserver.domain.member.entity.Gender;
 import com.mobble.mobbleserver.domain.member.entity.Member;
 
@@ -9,7 +10,7 @@ public record MemberResponseDto(
         Gender gender,
         String email,
         String phone,
-        String ground,
+        GroundResponseDto ground,
         String profileImage
 ) {
 
@@ -20,7 +21,7 @@ public record MemberResponseDto(
                 member.getGender(),
                 member.getEmail(),
                 member.getPhone(),
-                member.getGround(),
+                GroundResponseDto.toDto(member.getGround()),
                 member.getProfileImage()
         );
     }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.mobble.mobbleserver.domain.member.entity;
 
 import com.mobble.mobbleserver.account.auth.oauth.service.SocialProvider;
 import com.mobble.mobbleserver.common.baseEntity.BaseEntity;
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
 import com.mobble.mobbleserver.global.exception.common.DomainException;
 import com.mobble.mobbleserver.global.exception.errorCode.member.MemberErrorCode;
 import jakarta.persistence.*;
@@ -38,8 +39,9 @@ public class Member extends BaseEntity {
     @Column(name = "phone")
     private String phone;
 
-    @Column(name = "ground")
-    private String ground;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ground_code", nullable = false)
+    private Ground ground;
 
     @Column(name = "profile_image")
     private String profileImage;
@@ -70,7 +72,7 @@ public class Member extends BaseEntity {
             Gender gender,
             String email,
             String phone,
-            String ground,
+            Ground ground,
             String profileImage,
             boolean termsAgreed,
             boolean privacyAgreed,
@@ -78,7 +80,7 @@ public class Member extends BaseEntity {
             SocialProvider socialProvider,
             String socialId
     ) {
-        validateCommon(name, gender, phone, ground, termsAgreed, privacyAgreed);
+        validateCommon(name, gender, phone, termsAgreed, privacyAgreed);
         this.name = name;
         this.age = age;
         this.gender = gender;
@@ -102,7 +104,7 @@ public class Member extends BaseEntity {
             Gender gender,
             String email,
             String phone,
-            String ground,
+            Ground ground,
             String profileImage,
             boolean termsAgreed,
             boolean privacyAgreed,
@@ -126,8 +128,7 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    public Member updateMember(String ground, String profileImage) {
-        if (ground == null || ground.isBlank()) throw new DomainException(MemberErrorCode.GROUND_REQUIRED);
+    public Member updateMember(Ground ground, String profileImage) {
         this.ground = ground;
         this.profileImage = profileImage;
         return this;
@@ -142,15 +143,17 @@ public class Member extends BaseEntity {
             String name,
             Gender gender,
             String phone,
-            String ground,
             boolean termsAgreed,
             boolean privacyAgreed
     ) {
         if (name == null) throw new DomainException(MemberErrorCode.NAME_REQUIRED);
         if (gender == null) throw new DomainException(MemberErrorCode.GENDER_REQUIRED);
         if (phone == null) throw new DomainException(MemberErrorCode.PHONE_REQUIRED);
-        if (ground == null) throw new DomainException(MemberErrorCode.GROUND_REQUIRED);
         if (!termsAgreed) throw new DomainException(MemberErrorCode.TERMS_AGREED_REQUIRED);
         if (!privacyAgreed) throw new DomainException(MemberErrorCode.PRIVACY_AGREED_REQUIRED);
+    }
+
+    public void setGround(Ground ground) {
+        this.ground = ground;
     }
 }

--- a/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/mobble/mobbleserver/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.mobble.mobbleserver.domain.member.service;
 
+import com.mobble.mobbleserver.domain.ground.entity.Ground;
+import com.mobble.mobbleserver.domain.ground.repository.GroundRepository;
 import com.mobble.mobbleserver.domain.member.dto.request.MemberUpdateRequestDto;
 import com.mobble.mobbleserver.domain.member.dto.response.MemberResponseDto;
 import com.mobble.mobbleserver.domain.member.entity.Member;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberValidator memberValidator;
+    private final GroundRepository groundRepository;
 
     public MemberResponseDto getMember(Long memberId) {
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
@@ -24,7 +27,8 @@ public class MemberService {
     @Transactional
     public MemberResponseDto updateMember(Long memberId, MemberUpdateRequestDto dto) {
         Member member = memberValidator.findMemberByMemberIdOrThrow(memberId);
-        Member updateMember = member.updateMember(dto.ground(), dto.profileImage());
+        Ground ground = groundRepository.findGroundByCode(dto.groundCode()).get();
+        Member updateMember = member.updateMember(ground, dto.profileImage());
 
         return MemberResponseDto.toDto(updateMember);
     }


### PR DESCRIPTION
## 📄 Club 검색 API  추가 (다중 조건 및 정렬 지원)
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #203 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- 클럽 검색 엔드포인트 ```/api/search/clubs``` 추가
- ```이름```, ```지역```,``` 카테고리```, ```거리```, ```자동가입 ```여부 등 다중 검색 조건 처리
- ```좋아요```/```인원수```/```최신순 ```정렬옵션 지원
- DTO 분리 및  QueryDSL 기반 동적 쿼리 구성


## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인

