### PR TITLE
Refactor/member

### DIFF
--- a/src/main/java/com/mobble/mobbleserver/application/account/service/SignUpDetailsInfoService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/account/service/SignUpDetailsInfoService.java
@@ -1,6 +1,7 @@
 package com.mobble.mobbleserver.application.account.service;
 
 import com.mobble.mobbleserver.application.account.command.SignUpCommand;
+import com.mobble.mobbleserver.application.account.command.SocialProvider;
 import com.mobble.mobbleserver.application.account.command.SocialUserInfo;
 import com.mobble.mobbleserver.application.account.provided.SignUpDetailsPort;
 import com.mobble.mobbleserver.application.account.required.JwtTokenIssuerPort;
@@ -8,6 +9,8 @@ import com.mobble.mobbleserver.application.account.required.SignUpTokenPort;
 import com.mobble.mobbleserver.application.exception.BusinessException;
 import com.mobble.mobbleserver.application.image.error.ImageBusinessError;
 import com.mobble.mobbleserver.application.image.port.required.ImageReadPort;
+import com.mobble.mobbleserver.application.member.error.MemberBusinessError;
+import com.mobble.mobbleserver.application.member.port.required.MemberReadPort;
 import com.mobble.mobbleserver.application.member.port.required.MemberWritePort;
 import com.mobble.mobbleserver.domain.common.Location;
 import com.mobble.mobbleserver.domain.image.Image;
@@ -24,6 +27,7 @@ public class SignUpDetailsInfoService implements SignUpDetailsPort {
 
     private final SignUpTokenPort signUpTokenPort;
     private final JwtTokenIssuerPort jwtTokenIssuerPort;
+    private final MemberReadPort memberReadPort;
     private final ImageReadPort imageReadPort;
 
     private final MemberWritePort memberWritePort;
@@ -38,6 +42,10 @@ public class SignUpDetailsInfoService implements SignUpDetailsPort {
     @Transactional
     public String signUp(SignUpCommand command) {
         SocialUserInfo userInfo = signUpTokenPort.extractSignUpInfo(command.signUpToken());
+
+        Member existingMember = assertExistingMemberBySocialProviderAndSocialId(userInfo.socialProvider(), userInfo.socialId());
+        if (existingMember != null) return jwtTokenIssuerPort.issueJwtToken(existingMember.getId());
+
         Image profileImage = resolveProfileImage(command.profileImageId());
 
         Location location = Location.create(
@@ -69,6 +77,17 @@ public class SignUpDetailsInfoService implements SignUpDetailsPort {
     }
 
     /* ==== Private Helper ==== */
+    private Member assertExistingMemberBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId) {
+        return memberReadPort.findBySocialProviderAndSocialId(socialProvider, socialId)
+                .map(member -> {
+                    if (member.isDeleted()) {
+                        throw new BusinessException(MemberBusinessError.FAILED_JOIN);
+                    }
+                    return member;
+                })
+                .orElse(null); //신규 회원 이라면 null
+    }
+
     private Image resolveProfileImage(Long imageId) {
         return (imageId == null)
                 ? assertDefaultImageByImageType()

--- a/src/main/java/com/mobble/mobbleserver/application/account/service/SignUpDetailsInfoService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/account/service/SignUpDetailsInfoService.java
@@ -11,6 +11,7 @@ import com.mobble.mobbleserver.application.image.port.required.ImageReadPort;
 import com.mobble.mobbleserver.application.member.port.required.MemberWritePort;
 import com.mobble.mobbleserver.domain.common.Location;
 import com.mobble.mobbleserver.domain.image.Image;
+import com.mobble.mobbleserver.domain.image.ImageType;
 import com.mobble.mobbleserver.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -70,8 +71,13 @@ public class SignUpDetailsInfoService implements SignUpDetailsPort {
     /* ==== Private Helper ==== */
     private Image resolveProfileImage(Long imageId) {
         return (imageId == null)
-                ? null // Todo: getDefaultImage 메서드 호출
+                ? assertDefaultImageByImageType()
                 : assertImageByImageId(imageId);
+    }
+
+    private Image assertDefaultImageByImageType() {
+        return imageReadPort.findDefaultByType(ImageType.MEMBER_PROFILE)
+                .orElseThrow(() -> new BusinessException(ImageBusinessError.NOT_FOUND));
     }
 
     private Image assertImageByImageId(Long imageId) {

--- a/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
@@ -37,7 +37,7 @@ public class SocialLoginService implements SocialLoginPort {
     public SocialLoginResult socialLogin(SocialLoginCommand command) {
         SocialUserInfo userInfo = socialIdentityClientPort.verify(command.socialProvider(), command.accessToken());
 
-        Member member = assertexistingMemberBySocialProviderAndSocialId(userInfo.socialProvider(), userInfo.socialId());
+        Member member = assertExistingMemberBySocialProviderAndSocialId(userInfo.socialProvider(), userInfo.socialId());
 
         if (member != null) {
             List<ClubMemberRole> roles = clubMemberReadPort.findDistinctRolesByMemberIdAndRoleIn(member.getId(), List.of(ClubMemberRole.LEADER, ClubMemberRole.MANAGER));
@@ -53,7 +53,7 @@ public class SocialLoginService implements SocialLoginPort {
         return SocialLoginResult.newMember(signupToken);
     }
 
-    private Member assertexistingMemberBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId) {
+    private Member assertExistingMemberBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId) {
         return memberReadPort.findBySocialProviderAndSocialId(socialProvider, socialId)
                 .map(member -> {
                     if (member.isDeleted()) {

--- a/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
@@ -53,6 +53,7 @@ public class SocialLoginService implements SocialLoginPort {
         return SocialLoginResult.newMember(signupToken);
     }
 
+    /* ==== Private Helper ==== */
     private Member assertExistingMemberBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId) {
         return memberReadPort.findBySocialProviderAndSocialId(socialProvider, socialId)
                 .map(member -> {

--- a/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/account/service/SocialLoginService.java
@@ -37,7 +37,7 @@ public class SocialLoginService implements SocialLoginPort {
     public SocialLoginResult socialLogin(SocialLoginCommand command) {
         SocialUserInfo userInfo = socialIdentityClientPort.verify(command.socialProvider(), command.accessToken());
 
-        Member member = assertMemberOrThrowIfDeleted(userInfo.socialProvider(), userInfo.socialId());
+        Member member = assertexistingMemberBySocialProviderAndSocialId(userInfo.socialProvider(), userInfo.socialId());
 
         if (member != null) {
             List<ClubMemberRole> roles = clubMemberReadPort.findDistinctRolesByMemberIdAndRoleIn(member.getId(), List.of(ClubMemberRole.LEADER, ClubMemberRole.MANAGER));
@@ -53,7 +53,7 @@ public class SocialLoginService implements SocialLoginPort {
         return SocialLoginResult.newMember(signupToken);
     }
 
-    private Member assertMemberOrThrowIfDeleted(SocialProvider socialProvider, String socialId) {
+    private Member assertexistingMemberBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId) {
         return memberReadPort.findBySocialProviderAndSocialId(socialProvider, socialId)
                 .map(member -> {
                     if (member.isDeleted()) {

--- a/src/main/java/com/mobble/mobbleserver/application/member/service/MemberModifyService.java
+++ b/src/main/java/com/mobble/mobbleserver/application/member/service/MemberModifyService.java
@@ -12,6 +12,7 @@ import com.mobble.mobbleserver.application.member.port.required.MemberReadPort;
 import com.mobble.mobbleserver.application.member.port.required.MemberWritePort;
 import com.mobble.mobbleserver.domain.common.Location;
 import com.mobble.mobbleserver.domain.image.Image;
+import com.mobble.mobbleserver.domain.image.ImageType;
 import com.mobble.mobbleserver.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,8 +82,13 @@ public class MemberModifyService implements MemberUpdatePort, MemberSoftDeletePo
 
     private Image resolveProfileImage(Long imageId) {
         return (imageId == null)
-                ? null // Todo: getDefaultImage 메서드 호출
+                ? assertDefaultImageByImageType()
                 : assertImageByImageId(imageId);
+    }
+
+    private Image assertDefaultImageByImageType() {
+        return imageReadPort.findDefaultByType(ImageType.MEMBER_PROFILE)
+                .orElseThrow(() -> new BusinessException(ImageBusinessError.NOT_FOUND));
     }
 
     private Image assertImageByImageId(Long imageId) {

--- a/src/main/java/com/mobble/mobbleserver/infrastructure/web/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/mobble/mobbleserver/infrastructure/web/member/dto/response/MemberResponseDto.java
@@ -36,8 +36,8 @@ public record MemberResponseDto(
                 member.getLocation().getLatitude(),
                 member.getLocation().getLongitude(),
 
-                member.getProfileImage().getId(),
-                member.getProfileImage().getUrl()
+                member.getProfileImage() != null ? member.getProfileImage().getId() : null,
+                member.getProfileImage() != null ? member.getProfileImage().getUrl() : null
         );
     }
 }


### PR DESCRIPTION
## 📄 Refactor: 중복 회원 가입 방지 로직 추가
<!-- ex. feat: 회원가입 API 구현 -->

#### 📎 관련 이슈
<!-- 연결된 이슈 번호 -->
close #271 

## ✅ 변경 사항
<!-- 어떤 작업을 했는지 간략히 정리 -->
- SignUpDetailsInfoService: 회원 가입 재시도 시 중복으로 회원가입 되는 로직 추가
  - 기존 회원 유무 검증 -> 기존 회원이면 JwtToken 발급, 신규 회원이면 회원 가입 진행
- Member 조회, 수정 시 이미지가 없는 경우 defaultImage 반환 되도록 수정

## 🔍 테스트 방법
<!-- 어떤 방식으로 동작을 검증했는지 -->
- [x] 로컬에서 직접 테스트
- [ ] 유닛 테스트 작성 및 통과
- [ ] 브라우저 / 앱 화면에서 확인